### PR TITLE
Fix pagination limit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.pmckeown</groupId>
     <artifactId>dependency-track-maven-plugin</artifactId>
-    <version>0.8.2-SNAPSHOT</version>
+    <version>0.8.1</version>
     <packaging>maven-plugin</packaging>
 
     <name>Dependency Track Maven Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.pmckeown</groupId>
     <artifactId>dependency-track-maven-plugin</artifactId>
-    <version>0.8.1</version>
+    <version>0.8.2-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>Dependency Track Maven Plugin</name>

--- a/src/main/java/io/github/pmckeown/dependencytrack/ResourceConstants.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/ResourceConstants.java
@@ -9,7 +9,7 @@ public class ResourceConstants {
 
     public static final String V1_BOM = "/api/v1/bom";
     public static final String V1_BOM_TOKEN_UUID = "/api/v1/bom/token/{uuid}";
-    public static final String V1_PROJECT = "/api/v1/project";
+    public static final String V1_PROJECT = "/api/v1/project?limit=1000000&offset=0";
     public static final String V1_PROJECT_UUID = "/api/v1/project/{uuid}";
     public static final String V1_FINDING_PROJECT_UUID = "/api/v1/finding/project/{uuid}";
     public static final String V1_METRICS_PROJECT_UUID_CURRENT = "/api/v1/metrics/project/{uuid}/current";

--- a/src/test/java/io/github/pmckeown/dependencytrack/finding/FindingsMojoIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/finding/FindingsMojoIntegrationTest.java
@@ -35,7 +35,7 @@ public class FindingsMojoIntegrationTest extends AbstractDependencyTrackMojoTest
 
     @Test
     public void thatFindingMojoCanRetrieveFindingsAndPrintThem() throws Exception {
-        stubFor(get(urlPathMatching(V1_PROJECT)).willReturn(
+        stubFor(get(urlEqualTo(V1_PROJECT)).willReturn(
                 aResponse().withBodyFile("api/v1/project/get-all-projects.json")));
         stubFor(get(urlPathMatching(V1_FINDING_PROJECT_UUID)).willReturn(
                 aResponse().withBody(asJson(
@@ -60,7 +60,7 @@ public class FindingsMojoIntegrationTest extends AbstractDependencyTrackMojoTest
 
     @Test
     public void thatWhenNoFindingsAreFoundTheMojoDoesNotFail() throws Exception {
-        stubFor(get(urlPathMatching(V1_PROJECT)).willReturn(
+        stubFor(get(urlEqualTo(V1_PROJECT)).willReturn(
                 aResponse().withBodyFile("api/v1/project/get-all-projects.json")));
         stubFor(get(urlPathMatching(V1_FINDING_PROJECT_UUID)).willReturn(ok()));
 
@@ -81,7 +81,7 @@ public class FindingsMojoIntegrationTest extends AbstractDependencyTrackMojoTest
 
     @Test
     public void thatWhenExceptionOccursWhileGettingFindingsAndFailOnErrorIsTrueTheMojoErrors() throws Exception {
-        stubFor(get(urlPathMatching(V1_PROJECT)).willReturn(
+        stubFor(get(urlEqualTo(V1_PROJECT)).willReturn(
                 aResponse().withBodyFile("api/v1/project/get-all-projects.json")));
         stubFor(get(urlPathMatching(V1_FINDING_PROJECT_UUID)).willReturn(aResponse().withFault(RANDOM_DATA_THEN_CLOSE)));
 
@@ -102,7 +102,7 @@ public class FindingsMojoIntegrationTest extends AbstractDependencyTrackMojoTest
 
     @Test
     public void thatBuildFailsWhenFindingsNumberBreachesDefinedThresholds() throws Exception {
-        stubFor(get(urlPathMatching(V1_PROJECT)).willReturn(
+        stubFor(get(urlEqualTo(V1_PROJECT)).willReturn(
                 aResponse().withBodyFile("api/v1/project/get-all-projects.json")));
         stubFor(get(urlPathMatching(V1_FINDING_PROJECT_UUID)).willReturn(
                 aResponse().withBody(asJson(
@@ -130,7 +130,7 @@ public class FindingsMojoIntegrationTest extends AbstractDependencyTrackMojoTest
 
     @Test
     public void thatBuildDoesNotFailWhenOnlyUnassignedFindingExists() throws Exception {
-        stubFor(get(urlPathMatching(V1_PROJECT)).willReturn(
+        stubFor(get(urlEqualTo(V1_PROJECT)).willReturn(
                 aResponse().withBodyFile("api/v1/project/get-all-projects.json")));
         stubFor(get(urlPathMatching(V1_FINDING_PROJECT_UUID)).willReturn(
                 aResponse().withBody(asJson(

--- a/src/test/java/io/github/pmckeown/dependencytrack/metrics/MetricsMojoIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/metrics/MetricsMojoIntegrationTest.java
@@ -32,7 +32,7 @@ public class MetricsMojoIntegrationTest extends AbstractDependencyTrackMojoTest 
 
     @Test
     public void thatMetricsCanBeRetrievedForCurrentProject() throws Exception {
-        stubFor(get(urlPathMatching(V1_PROJECT)).willReturn(
+        stubFor(get(urlEqualTo(V1_PROJECT)).willReturn(
                 aResponse().withBodyFile("api/v1/project/get-all-projects.json")));
 
         MetricsMojo metricsMojo = loadMetricsMojo(mojoRule);
@@ -48,7 +48,7 @@ public class MetricsMojoIntegrationTest extends AbstractDependencyTrackMojoTest 
 
     @Test
     public void thatWhenMetricsAreNotInProjectTheyAreRetrievedExplicitly() throws Exception {
-        stubFor(get(urlPathMatching(V1_PROJECT)).willReturn(
+        stubFor(get(urlEqualTo(V1_PROJECT)).willReturn(
                 aResponse().withBodyFile("api/v1/project/get-all-projects.json")));
         stubFor(get(urlPathMatching(V1_METRICS_PROJECT_CURRENT)).willReturn(
                 aResponse().withBodyFile("api/v1/metrics/project/project-metrics.json")));
@@ -68,7 +68,7 @@ public class MetricsMojoIntegrationTest extends AbstractDependencyTrackMojoTest 
 
     @Test
     public void thatExceptionIsThrownWhenMetricsCannotBeRetrievedForCurrentProject() throws Exception {
-        stubFor(get(urlPathMatching(V1_PROJECT)).willReturn(
+        stubFor(get(urlEqualTo(V1_PROJECT)).willReturn(
                 aResponse().withBodyFile("api/v1/project/get-all-projects.json")));
         stubFor(get(urlPathMatching(V1_METRICS_PROJECT_CURRENT)).willReturn(
                 aResponse().withFault(Fault.MALFORMED_RESPONSE_CHUNK)));
@@ -89,7 +89,7 @@ public class MetricsMojoIntegrationTest extends AbstractDependencyTrackMojoTest 
 
     @Test
     public void thatAnyCriticalIssuesPresentCanFailTheBuild() throws Exception {
-        stubFor(get(urlPathMatching(V1_PROJECT)).willReturn(
+        stubFor(get(urlEqualTo(V1_PROJECT)).willReturn(
                 aResponse().withBody(asJson(
                         aListOfProjects()
                                 .withProject(aProject()


### PR DESCRIPTION
This is a work around for the 100 project pagination limit in dependency track. 
The solution was suggested by the developer of the framework.
https://groups.io/g/dependency-track/topic/71890367?p=Created,,,20,1,0,0::recentpostdate/sticky,,,20,2,0,71890367