### PR TITLE
Finding report is written to the wrong target for multi module projects

### DIFF
--- a/src/main/java/io/github/pmckeown/dependencytrack/finding/FindingsMojo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/finding/FindingsMojo.java
@@ -11,9 +11,12 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+
+import java.io.File;
 import java.util.List;
 
 import static org.apache.maven.plugins.annotations.LifecyclePhase.VERIFY;
@@ -64,6 +67,9 @@ public class FindingsMojo extends AbstractDependencyTrackMojo {
     @Parameter(name = "findingThresholds")
     private FindingThresholds findingThresholds;
 
+    @Parameter(defaultValue = "${project}", readonly = true, required = false)
+    private MavenProject mavenProject;
+
     private ProjectAction projectAction;
     private FindingsAction findingsAction;
     private FindingsPrinter findingsPrinter;
@@ -92,7 +98,7 @@ public class FindingsMojo extends AbstractDependencyTrackMojo {
 
             if (findingThresholds != null && !findings.isEmpty()) {
                 boolean policyBreached = findingsAnalyser.doNumberOfFindingsBreachPolicy(findings, findingThresholds);
-                findingsReportGenerator.generate(findings, findingThresholds, policyBreached);
+                findingsReportGenerator.generate(getOutputDirectory(), findings, findingThresholds, policyBreached);
 
                 if (policyBreached) {
                     throw new MojoFailureException("Number of findings exceeded defined thresholds");
@@ -108,5 +114,14 @@ public class FindingsMojo extends AbstractDependencyTrackMojo {
      */
     void setFindingThresholds(FindingThresholds findingThresholds) {
         this.findingThresholds = findingThresholds;
+    }
+
+    private File getOutputDirectory() {
+        if (mavenProject == null) {
+            return null;
+        }
+        else {
+            return new File(mavenProject.getBuild().getDirectory());
+        }
     }
 }

--- a/src/main/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportConstants.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportConstants.java
@@ -6,13 +6,11 @@ class FindingsReportConstants {
         // Do no instantiate
     }
 
-    static final String OUTPUT_DIRECTORY = "target";
-
     static final String META_INF_DIRECTORY = "/META-INF";
 
     static final String XSL_STYLESHEET_FILENAME = META_INF_DIRECTORY + "/dependency-track-findings-transformer.xsl";
 
-    static final String XML_REPORT_FILENAME = OUTPUT_DIRECTORY + "/dependency-track-findings.xml";
+    static final String XML_REPORT_FILENAME = "dependency-track-findings.xml";
 
-    static final String HTML_REPORT_FILENAME = OUTPUT_DIRECTORY + "/dependency-track-findings.html";
+    static final String HTML_REPORT_FILENAME = "dependency-track-findings.html";
 }

--- a/src/main/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportConstants.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportConstants.java
@@ -10,7 +10,7 @@ class FindingsReportConstants {
 
     static final String XSL_STYLESHEET_FILENAME = META_INF_DIRECTORY + "/dependency-track-findings-transformer.xsl";
 
-    static final String XML_REPORT_FILENAME = "dependency-track-findings.xml";
+    protected static final String XML_REPORT_FILENAME = "dependency-track-findings.xml";
 
-    static final String HTML_REPORT_FILENAME = "dependency-track-findings.html";
+    protected static final String HTML_REPORT_FILENAME = "dependency-track-findings.html";
 }

--- a/src/main/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportConstants.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportConstants.java
@@ -2,13 +2,13 @@ package io.github.pmckeown.dependencytrack.finding.report;
 
 class FindingsReportConstants {
 
-    private FindingsReportConstants() {
-        // Do no instantiate
-    }
-
     protected static final String XML_REPORT_FILENAME = "dependency-track-findings.xml";
 
     protected static final String HTML_REPORT_FILENAME = "dependency-track-findings.html";
+
+    private FindingsReportConstants() {
+        // Do no instantiate
+    }
 
     static final String META_INF_DIRECTORY = "/META-INF";
 

--- a/src/main/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportConstants.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportConstants.java
@@ -6,11 +6,12 @@ class FindingsReportConstants {
         // Do no instantiate
     }
 
+    protected static final String XML_REPORT_FILENAME = "dependency-track-findings.xml";
+
+    protected static final String HTML_REPORT_FILENAME = "dependency-track-findings.html";
+
     static final String META_INF_DIRECTORY = "/META-INF";
 
     static final String XSL_STYLESHEET_FILENAME = META_INF_DIRECTORY + "/dependency-track-findings-transformer.xsl";
 
-    protected static final String XML_REPORT_FILENAME = "dependency-track-findings.xml";
-
-    protected static final String HTML_REPORT_FILENAME = "dependency-track-findings.html";
 }

--- a/src/main/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportGenerator.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportGenerator.java
@@ -6,6 +6,8 @@ import io.github.pmckeown.dependencytrack.finding.FindingThresholds;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+
+import java.io.File;
 import java.util.List;
 
 @Singleton
@@ -20,10 +22,10 @@ public class FindingsReportGenerator {
         this.htmlReportWriter = htmlReportWriter;
     }
 
-    public void generate(List<Finding> findings, FindingThresholds findingThresholds, boolean policyBreached)
-            throws DependencyTrackException {
+    public void generate(File buildDirectory, List<Finding> findings, FindingThresholds findingThresholds, 
+            boolean policyBreached) throws DependencyTrackException {
         FindingsReport findingsReport = new FindingsReport(findingThresholds, findings, policyBreached);
-        xmlReportWriter.write(findingsReport);
-        htmlReportWriter.write();
+        xmlReportWriter.write(buildDirectory, findingsReport);
+        htmlReportWriter.write(buildDirectory);
     }
 }

--- a/src/main/java/io/github/pmckeown/dependencytrack/finding/report/HtmlReportWriter.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/finding/report/HtmlReportWriter.java
@@ -24,11 +24,11 @@ class HtmlReportWriter {
         this.transformerFactoryProvider = transformerFactoryProvider;
     }
 
-    void write() throws DependencyTrackException {
+    void write(File buildDirectory) throws DependencyTrackException {
         try {
             StreamSource stylesheet = new StreamSource(getStylesheetInputStream());
-            StreamSource input = new StreamSource(getInputFile());
-            StreamResult output = new StreamResult(new FileOutputStream(getOutputFile()));
+            StreamSource input = new StreamSource(getInputFile(buildDirectory));
+            StreamResult output = new StreamResult(new FileOutputStream(getOutputFile(buildDirectory)));
 
             Transformer transformer = getSecureTransformerFactory().newTransformer(stylesheet);
             transformer.transform(input, output);
@@ -43,12 +43,12 @@ class HtmlReportWriter {
         return transformerFactory;
     }
 
-    private File getInputFile() {
-        return new File(FindingsReportConstants.XML_REPORT_FILENAME);
+    private File getInputFile(File buildDirectory) {
+        return new File(buildDirectory, FindingsReportConstants.XML_REPORT_FILENAME);
     }
 
-    private File getOutputFile() {
-        return new File(FindingsReportConstants.HTML_REPORT_FILENAME);
+    private File getOutputFile(File buildDirectory) {
+        return new File(buildDirectory, FindingsReportConstants.HTML_REPORT_FILENAME);
     }
 
     private InputStream getStylesheetInputStream() {

--- a/src/main/java/io/github/pmckeown/dependencytrack/finding/report/XmlReportWriter.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/finding/report/XmlReportWriter.java
@@ -18,21 +18,20 @@ class XmlReportWriter {
         this.marshallerService = marshallerService;
     }
 
-    void write(FindingsReport findingsReport) throws DependencyTrackException {
+    void write(File buildDirectory, FindingsReport findingsReport) throws DependencyTrackException {
         try {
             Marshaller marshaller = marshallerService.getMarshaller();
-            File outputFile = getFile();
+            File outputFile = getFile(buildDirectory);
             marshaller.marshal(findingsReport, outputFile);
         } catch (JAXBException ex) {
             throw new DependencyTrackException("Error occurred while generating XML report", ex);
         }
     }
 
-    private File getFile() {
-        File targetDir = new File(FindingsReportConstants.OUTPUT_DIRECTORY);
-        if (!targetDir.exists()) {
-            targetDir.mkdir();
+    private File getFile(File buildDirectory) {
+        if (buildDirectory != null && !buildDirectory.exists()) {
+            buildDirectory.mkdir();
         }
-        return new File(FindingsReportConstants.XML_REPORT_FILENAME);
+        return new File(buildDirectory, FindingsReportConstants.XML_REPORT_FILENAME);
     }
 }

--- a/src/test/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportGeneratorTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportGeneratorTest.java
@@ -9,7 +9,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.io.File;
 import java.util.List;
 
 import static io.github.pmckeown.dependencytrack.finding.FindingListBuilder.aListOfFindings;

--- a/src/test/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportGeneratorTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportGeneratorTest.java
@@ -9,6 +9,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.io.File;
 import java.util.List;
 
 import static io.github.pmckeown.dependencytrack.finding.FindingListBuilder.aListOfFindings;
@@ -17,6 +18,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -37,10 +39,10 @@ public class FindingsReportGeneratorTest {
     public void thatBothReportsAreGenerated() throws Exception {
         FindingThresholds findingThresholds = new FindingThresholds(1, null, null, null, null);
         List<Finding> findings = aListOfFindings().build();
-        findingsReportGenerator.generate(findings, findingThresholds, false);
+        findingsReportGenerator.generate(null, findings, findingThresholds, false);
 
-        verify(xmlReportWriter).write(any(FindingsReport.class));
-        verify(htmlReportWriter).write();
+        verify(xmlReportWriter).write(isNull(), any(FindingsReport.class));
+        verify(htmlReportWriter).write(isNull());
     }
 
     @Test
@@ -48,10 +50,10 @@ public class FindingsReportGeneratorTest {
         FindingThresholds findingThresholds = new FindingThresholds(1, null, null, null, null);
         List<Finding> findings = aListOfFindings().build();
 
-        doThrow(DependencyTrackException.class).when(xmlReportWriter).write(any(FindingsReport.class));
+        doThrow(DependencyTrackException.class).when(xmlReportWriter).write(isNull(), any(FindingsReport.class));
 
         try {
-            findingsReportGenerator.generate(findings, findingThresholds, false);
+            findingsReportGenerator.generate(null, findings, findingThresholds, false);
             fail("Exception expected");
         } catch (Exception e) {
             assertThat(e, is(instanceOf(DependencyTrackException.class)));
@@ -65,15 +67,15 @@ public class FindingsReportGeneratorTest {
         FindingThresholds findingThresholds = new FindingThresholds(1, null, null, null, null);
         List<Finding> findings = aListOfFindings().build();
 
-        doThrow(DependencyTrackException.class).when(htmlReportWriter).write();
+        doThrow(DependencyTrackException.class).when(htmlReportWriter).write(isNull());
 
         try {
-            findingsReportGenerator.generate(findings, findingThresholds, false);
+            findingsReportGenerator.generate(null, findings, findingThresholds, false);
             fail("Exception expected");
         } catch (Exception e) {
             assertThat(e, is(instanceOf(DependencyTrackException.class)));
         }
 
-        verify(xmlReportWriter).write(any(FindingsReport.class));
+        verify(xmlReportWriter).write(isNull(), any(FindingsReport.class));
     }
 }

--- a/src/test/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportIntegrationTest.java
@@ -34,8 +34,9 @@ public class FindingsReportIntegrationTest {
     @Test
     public void thatXmlFileCanBeGenerated() {
         try {
-            xmlReportWriter.write(new FindingsReport(thresholds(), findings(), true));
-            assertThat(new File(FindingsReportConstants.XML_REPORT_FILENAME).exists(), is(true));
+        	File outputDirectory = new File("target");
+            xmlReportWriter.write(outputDirectory, new FindingsReport(thresholds(), findings(), true));
+            assertThat(new File(outputDirectory, FindingsReportConstants.XML_REPORT_FILENAME).exists(), is(true));
         } catch (Exception ex) {
             fail("Exception not expected");
         }
@@ -44,9 +45,10 @@ public class FindingsReportIntegrationTest {
     @Test
     public void thatXmlFileCanBeTransformed() {
         try {
-            xmlReportWriter.write(new FindingsReport(thresholds(), findings(), true));
-            htmlReportWriter.write();
-            assertThat(new File(FindingsReportConstants.HTML_REPORT_FILENAME).exists(), is(true));
+            File outputDirectory = new File("target");
+            xmlReportWriter.write(outputDirectory, new FindingsReport(thresholds(), findings(), true));
+            htmlReportWriter.write(outputDirectory);
+            assertThat(new File(outputDirectory, FindingsReportConstants.HTML_REPORT_FILENAME).exists(), is(true));
         } catch (Exception ex) {
             ex.printStackTrace();
             fail("Exception not expected");

--- a/src/test/java/io/github/pmckeown/dependencytrack/finding/report/XmlReportWriterTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/finding/report/XmlReportWriterTest.java
@@ -48,7 +48,7 @@ public class XmlReportWriterTest {
     @Test
     public void thatFindingReportCanBeMarshalled() {
         try {
-            xmlReportWriter.write(new FindingsReport(someFindingThresholds(), someFindings(), true));
+            xmlReportWriter.write(null, new FindingsReport(someFindingThresholds(), someFindings(), true));
         } catch (Exception ex) {
             fail(format("No exception expected but got: %s", ex.getMessage()));
         }
@@ -58,7 +58,7 @@ public class XmlReportWriterTest {
     public void thatAnExceptionIsThrownWhenMarshallingFails() throws Exception {
         doThrow(JAXBException.class).when(marshaller).marshal(any(FindingsReport.class), any(File.class));
         try {
-            xmlReportWriter.write(new FindingsReport(someFindingThresholds(), someFindings(), true));
+            xmlReportWriter.write(null, new FindingsReport(someFindingThresholds(), someFindings(), true));
             fail("Exception expected but none occurred");
         } catch (Exception ex) {
             assertThat(ex, instanceOf(DependencyTrackException.class));


### PR DESCRIPTION
The files are currently written to: current directory + "target".
In case of a multi module maven project it effectively means the reports will be overwritten and only the last generated report is there.

This change ensures the reports are written to the current project's build directory.