### PR TITLE
set skip using system property

### DIFF
--- a/src/main/java/io/github/pmckeown/dependencytrack/AbstractDependencyTrackMojo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/AbstractDependencyTrackMojo.java
@@ -70,7 +70,7 @@ public abstract class AbstractDependencyTrackMojo extends AbstractMojo {
         this.commonConfig.setPollingConfig(this.pollingConfig != null ? this.pollingConfig : PollingConfig.defaults());
 
         // Perform the requested action
-        if (skip) {
+        if (getSkip()) {
             logger.info("dependency-track.skip = true: Skipping analysis.");
             return;
         }
@@ -127,4 +127,7 @@ public abstract class AbstractDependencyTrackMojo extends AbstractMojo {
         }
     }
 
+    private boolean getSkip() {
+        return Boolean.parseBoolean(System.getProperty("dependency-track.skip", Boolean.toString(skip)));
+    }
 }


### PR DESCRIPTION
skip can be passed as a system property using the -D or --define switch in Maven.  
Given a pom.xml configuration:
```
                <groupId>io.github.pmckeown</groupId>
                <artifactId>dependency-track-maven-plugin</artifactId>
                <version>${dependency-track.version}</version>
                <configuration>
                    <dependencyTrackBaseUrl>https://dependency-track.example.com</dependencyTrackBaseUrl>
                    <apiKey>EXAMPLE_API_KEY</apiKey>
                    <skip>true</skip>
                </configuration>
```
And enable during CICD pipeline execution using Maven command:
```
mvn dependency-track:upload-bom -D dependency-track.skip=false
```
The upload is executed.