### PR TITLE
Use non-deprecated assertThat() in tests

### DIFF
--- a/src/test/java/io/github/pmckeown/dependencytrack/PollerTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/PollerTest.java
@@ -13,7 +13,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/src/test/java/io/github/pmckeown/dependencytrack/PollingConfigTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/PollingConfigTest.java
@@ -6,7 +6,7 @@ import java.time.temporal.ChronoUnit;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class PollingConfigTest {
 

--- a/src/test/java/io/github/pmckeown/dependencytrack/finding/FindingsActionTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/finding/FindingsActionTest.java
@@ -23,7 +23,7 @@ import static io.github.pmckeown.dependencytrack.finding.VulnerabilityBuilder.aV
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;

--- a/src/test/java/io/github/pmckeown/dependencytrack/finding/FindingsAnalyserTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/finding/FindingsAnalyserTest.java
@@ -23,7 +23,7 @@ import static io.github.pmckeown.dependencytrack.finding.VulnerabilityBuilder.aV
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/src/test/java/io/github/pmckeown/dependencytrack/finding/FindingsClientTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/finding/FindingsClientTest.java
@@ -36,7 +36,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/src/test/java/io/github/pmckeown/dependencytrack/finding/FindingsMojoIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/finding/FindingsMojoIntegrationTest.java
@@ -29,7 +29,7 @@ import static io.github.pmckeown.dependencytrack.finding.Severity.UNASSIGNED;
 import static io.github.pmckeown.dependencytrack.finding.VulnerabilityBuilder.aVulnerability;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 public class FindingsMojoIntegrationTest extends AbstractDependencyTrackMojoTest {

--- a/src/test/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportGeneratorTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportGeneratorTest.java
@@ -14,7 +14,7 @@ import java.util.List;
 import static io.github.pmckeown.dependencytrack.finding.FindingListBuilder.aListOfFindings;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;

--- a/src/test/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportIntegrationTest.java
@@ -17,7 +17,7 @@ import static io.github.pmckeown.dependencytrack.finding.FindingBuilder.aFinding
 import static io.github.pmckeown.dependencytrack.finding.FindingListBuilder.aListOfFindings;
 import static io.github.pmckeown.dependencytrack.finding.VulnerabilityBuilder.aVulnerability;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 public class FindingsReportIntegrationTest {

--- a/src/test/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportTest.java
@@ -14,7 +14,7 @@ import static io.github.pmckeown.dependencytrack.finding.FindingListBuilder.aLis
 import static io.github.pmckeown.dependencytrack.finding.VulnerabilityBuilder.aVulnerability;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class FindingsReportTest {
 

--- a/src/test/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportXmlReportWriterTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportXmlReportWriterTest.java
@@ -22,7 +22,7 @@ import static io.github.pmckeown.dependencytrack.finding.FindingListBuilder.aLis
 import static io.github.pmckeown.dependencytrack.finding.VulnerabilityBuilder.aVulnerability;
 import static java.lang.String.format;
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;

--- a/src/test/java/io/github/pmckeown/dependencytrack/metrics/MetricsActionTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/metrics/MetricsActionTest.java
@@ -22,7 +22,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;

--- a/src/test/java/io/github/pmckeown/dependencytrack/metrics/MetricsAnalyserTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/metrics/MetricsAnalyserTest.java
@@ -16,7 +16,7 @@ import static io.github.pmckeown.dependencytrack.Constants.UNASSIGNED;
 import static io.github.pmckeown.dependencytrack.metrics.MetricsBuilder.aMetrics;
 import static io.github.pmckeown.dependencytrack.metrics.MetricsAnalyser.ERROR_TEMPLATE;
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.verify;
 

--- a/src/test/java/io/github/pmckeown/dependencytrack/metrics/MetricsClientTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/metrics/MetricsClientTest.java
@@ -25,7 +25,7 @@ import static io.github.pmckeown.dependencytrack.project.ProjectBuilder.aProject
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.doReturn;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/src/test/java/io/github/pmckeown/dependencytrack/metrics/MetricsMojoIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/metrics/MetricsMojoIntegrationTest.java
@@ -26,7 +26,7 @@ import static io.github.pmckeown.dependencytrack.project.ProjectBuilder.aProject
 import static io.github.pmckeown.dependencytrack.project.ProjectListBuilder.aListOfProjects;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 public class MetricsMojoIntegrationTest extends AbstractDependencyTrackMojoTest {

--- a/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsActionTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsActionTest.java
@@ -22,7 +22,7 @@ import static io.github.pmckeown.dependencytrack.project.ProjectBuilder.aProject
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;

--- a/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsClientTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsClientTest.java
@@ -34,7 +34,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsMojoIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsMojoIntegrationTest.java
@@ -21,7 +21,7 @@ import static io.github.pmckeown.dependencytrack.ResourceConstants.V1_PROJECT;
 import static io.github.pmckeown.dependencytrack.TestResourceConstants.V1_POLICY_VIOLATION_PROJECT_UUID;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 public class PolicyViolationsMojoIntegrationTest extends AbstractDependencyTrackMojoTest {

--- a/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/report/PolicyViolationsReportGeneratorTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/report/PolicyViolationsReportGeneratorTest.java
@@ -15,7 +15,7 @@ import java.util.List;
 import static io.github.pmckeown.dependencytrack.policyviolation.PolicyViolationListBuilder.aListOfPolicyViolations;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;

--- a/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/report/PolicyViolationsReportIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/report/PolicyViolationsReportIntegrationTest.java
@@ -16,7 +16,7 @@ import static io.github.pmckeown.dependencytrack.policyviolation.PolicyCondition
 import static io.github.pmckeown.dependencytrack.policyviolation.PolicyViolationBuilder.aPolicyViolation;
 import static io.github.pmckeown.dependencytrack.policyviolation.PolicyViolationListBuilder.aListOfPolicyViolations;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 public class PolicyViolationsReportIntegrationTest {

--- a/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/report/PolicyViolationsReportTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/report/PolicyViolationsReportTest.java
@@ -10,7 +10,7 @@ import static io.github.pmckeown.dependencytrack.policyviolation.PolicyViolation
 import static io.github.pmckeown.dependencytrack.policyviolation.PolicyViolationListBuilder.aListOfPolicyViolations;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class PolicyViolationsReportTest {
 

--- a/src/test/java/io/github/pmckeown/dependencytrack/project/DeleteProjectActionTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/project/DeleteProjectActionTest.java
@@ -15,7 +15,7 @@ import static io.github.pmckeown.dependencytrack.ResponseBuilder.aSuccessRespons
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;

--- a/src/test/java/io/github/pmckeown/dependencytrack/project/DeleteProjectMojoIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/project/DeleteProjectMojoIntegrationTest.java
@@ -21,7 +21,7 @@ import static io.github.pmckeown.dependencytrack.ResourceConstants.V1_PROJECT;
 import static io.github.pmckeown.dependencytrack.TestResourceConstants.V1_PROJECT_UUID;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 public class DeleteProjectMojoIntegrationTest extends AbstractDependencyTrackMojoTest {
@@ -143,4 +143,3 @@ public class DeleteProjectMojoIntegrationTest extends AbstractDependencyTrackMoj
         verify(exactly(0), deleteRequestedFor(urlPathMatching(V1_PROJECT_UUID)));
     }
 }
-

--- a/src/test/java/io/github/pmckeown/dependencytrack/project/ProjectActionTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/project/ProjectActionTest.java
@@ -19,7 +19,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 

--- a/src/test/java/io/github/pmckeown/dependencytrack/project/ProjectClientIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/project/ProjectClientIntegrationTest.java
@@ -9,7 +9,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static io.github.pmckeown.dependencytrack.TestResourceConstants.V1_PROJECT_WITH_ONE_MILLION_LIMIT;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Collections;
 import java.util.List;

--- a/src/test/java/io/github/pmckeown/dependencytrack/score/ScoreActionTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/score/ScoreActionTest.java
@@ -21,7 +21,7 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;

--- a/src/test/java/io/github/pmckeown/dependencytrack/score/ScoreMojoIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/score/ScoreMojoIntegrationTest.java
@@ -12,7 +12,7 @@ import static io.github.pmckeown.dependencytrack.ResourceConstants.V1_PROJECT;
 import static io.github.pmckeown.dependencytrack.TestResourceConstants.V1_METRICS_PROJECT_CURRENT;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 public class ScoreMojoIntegrationTest extends AbstractDependencyTrackMojoTest {

--- a/src/test/java/io/github/pmckeown/dependencytrack/upload/BomClientIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/upload/BomClientIntegrationTest.java
@@ -28,7 +28,7 @@ import static io.github.pmckeown.dependencytrack.upload.UploadBomResponseBuilder
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 public class BomClientIntegrationTest extends AbstractDependencyTrackIntegrationTest {

--- a/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomActionTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomActionTest.java
@@ -18,7 +18,7 @@ import static io.github.pmckeown.dependencytrack.upload.UploadBomResponseBuilder
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;

--- a/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoIntegrationTest.java
@@ -18,7 +18,7 @@ import static io.github.pmckeown.dependencytrack.ResourceConstants.V1_BOM;
 import static io.github.pmckeown.dependencytrack.ResourceConstants.V1_PROJECT;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -209,4 +209,3 @@ public class UploadBomMojoIntegrationTest extends AbstractDependencyTrackMojoTes
         return uploadBomMojo;
     }
 }
-

--- a/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoTest.java
@@ -18,7 +18,7 @@ import java.io.File;
 import static io.github.pmckeown.dependencytrack.project.ProjectBuilder.aProject;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/io/github/pmckeown/util/BomEncoderTest.java
+++ b/src/test/java/io/github/pmckeown/util/BomEncoderTest.java
@@ -8,7 +8,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @RunWith(MockitoJUnitRunner.class)
 public class BomEncoderTest {

--- a/src/test/java/io/github/pmckeown/util/LoggerTest.java
+++ b/src/test/java/io/github/pmckeown/util/LoggerTest.java
@@ -10,7 +10,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 


### PR DESCRIPTION
Update the `assertThat` imports so it uses the non-deprecated implementation.

This doesn't change the test logic at all.

See #301 