### PR TITLE
allows working without certificate validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ of this plugin:
 |projectName           |false   |${project.artifactId}|
 |projectVersion        |false   |${project.version}   |
 |failOnError           |false   |false                |  
-|validateCertificationPath           |false   |false                |  
+|verifySsl             |false   |false                |  
 |skip                  |false   |false                |  
 
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ of this plugin:
 |projectName           |false   |${project.artifactId}|
 |projectVersion        |false   |${project.version}   |
 |failOnError           |false   |false                |  
+|validateCertificationPath           |false   |false                |  
 |skip                  |false   |false                |  
 
 

--- a/src/main/java/io/github/pmckeown/dependencytrack/AbstractDependencyTrackMojo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/AbstractDependencyTrackMojo.java
@@ -35,6 +35,9 @@ public abstract class AbstractDependencyTrackMojo extends AbstractMojo {
     @Parameter(required = true, property = "dependency-track.apiKey")
     private String apiKey;
 
+    @Parameter(defaultValue = "true", property = "dependency-track.verifySsl")
+    private boolean verifySsl;
+
     @Parameter(defaultValue = "false", property = "dependency-track.failOnError")
     private boolean failOnError;
 
@@ -67,6 +70,7 @@ public abstract class AbstractDependencyTrackMojo extends AbstractMojo {
         this.commonConfig.setProjectVersion(projectVersion);
         this.commonConfig.setDependencyTrackBaseUrl(dependencyTrackBaseUrl);
         this.commonConfig.setApiKey(apiKey);
+        this.commonConfig.setVerifySsl(verifySsl);
         this.commonConfig.setPollingConfig(this.pollingConfig != null ? this.pollingConfig : PollingConfig.defaults());
 
         // Perform the requested action
@@ -105,6 +109,10 @@ public abstract class AbstractDependencyTrackMojo extends AbstractMojo {
         this.failOnError = fail;
     }
 
+    public void setVerifySsl(boolean verifySsl) {
+        this.verifySsl = verifySsl;
+    }
+    
     public void setSkip(boolean skip) {
         this.skip = skip;
     }

--- a/src/main/java/io/github/pmckeown/dependencytrack/CommonConfig.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/CommonConfig.java
@@ -14,20 +14,20 @@ public class CommonConfig {
     private String projectVersion;
     private String dependencyTrackBaseUrl;
     private String apiKey;
-    private boolean validateCertificationPath;
+    private boolean verifySsl;
     private PollingConfig pollingConfig;
 
     public CommonConfig() {
         // For dependency injection
     }
 
-    public CommonConfig(String projectName, String projectVersion, String dependencyTrackBaseUrl, String apiKey, boolean validateCertificationPath,
+    public CommonConfig(String projectName, String projectVersion, String dependencyTrackBaseUrl, String apiKey, boolean verifySsl,
             PollingConfig pollingConfig) {
         this.projectName = projectName;
         this.projectVersion = projectVersion;
         this.dependencyTrackBaseUrl = dependencyTrackBaseUrl;
         this.apiKey = apiKey;
-        this.validateCertificationPath = validateCertificationPath;
+        this.verifySsl = verifySsl;
         this.pollingConfig = pollingConfig;
     }
 
@@ -71,13 +71,15 @@ public class CommonConfig {
         this.pollingConfig = pollingConfig;
     }
 
-    public boolean isValidateCertificationPath() {
-        return validateCertificationPath;
+    public boolean isVerifySsl() {
+        return verifySsl;
     }
 
-    public void setValidateCertificationPath(boolean validateCertificationPath) {
-        this.validateCertificationPath = validateCertificationPath;
+    public void setVerifySsl(boolean verifySsl) {
+        this.verifySsl = verifySsl;
     }
+
+    
     
     
 }

--- a/src/main/java/io/github/pmckeown/dependencytrack/CommonConfig.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/CommonConfig.java
@@ -14,18 +14,20 @@ public class CommonConfig {
     private String projectVersion;
     private String dependencyTrackBaseUrl;
     private String apiKey;
+    private boolean validateCertificationPath;
     private PollingConfig pollingConfig;
 
     public CommonConfig() {
         // For dependency injection
     }
 
-    public CommonConfig(String projectName, String projectVersion, String dependencyTrackBaseUrl, String apiKey,
+    public CommonConfig(String projectName, String projectVersion, String dependencyTrackBaseUrl, String apiKey, boolean validateCertificationPath,
             PollingConfig pollingConfig) {
         this.projectName = projectName;
         this.projectVersion = projectVersion;
         this.dependencyTrackBaseUrl = dependencyTrackBaseUrl;
         this.apiKey = apiKey;
+        this.validateCertificationPath = validateCertificationPath;
         this.pollingConfig = pollingConfig;
     }
 
@@ -68,4 +70,14 @@ public class CommonConfig {
     public void setPollingConfig(PollingConfig pollingConfig) {
         this.pollingConfig = pollingConfig;
     }
+
+    public boolean isValidateCertificationPath() {
+        return validateCertificationPath;
+    }
+
+    public void setValidateCertificationPath(boolean validateCertificationPath) {
+        this.validateCertificationPath = validateCertificationPath;
+    }
+    
+    
 }

--- a/src/main/java/io/github/pmckeown/dependencytrack/upload/BomClient.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/upload/BomClient.java
@@ -33,9 +33,10 @@ class BomClient {
     @Inject
     BomClient(CommonConfig commonConfig) {
         this.commonConfig = commonConfig;
-        Unirest.config()
-                .verifySsl(commonConfig.isValidateCertificationPath())
-                .setObjectMapper(new JacksonObjectMapper(relaxedObjectMapper()))
+    }
+
+    static {
+        Unirest.config().setObjectMapper(new JacksonObjectMapper(relaxedObjectMapper()))
                 .addDefaultHeader(ACCEPT_ENCODING, "gzip, deflate")
                 .addDefaultHeader(ACCEPT, "application/json");
     }
@@ -49,6 +50,8 @@ class BomClient {
      * @return a response containing a token to later determine if processing the supplied BOM is completed
      */
     Response<UploadBomResponse> uploadBom(UploadBomRequest bom) {
+        Unirest.config()
+                .verifySsl(commonConfig.isVerifySsl());
         RequestBodyEntity requestBodyEntity = Unirest.put(commonConfig.getDependencyTrackBaseUrl() + V1_BOM)
                 .header(CONTENT_TYPE, "application/json")
                 .header("X-Api-Key", commonConfig.getApiKey())
@@ -74,6 +77,8 @@ class BomClient {
      *         flag is false, processing is either completed or the token supplied was invalid.
      */
     Response<BomProcessingResponse> isBomBeingProcessed(String token) {
+        Unirest.config()
+                .verifySsl(commonConfig.isVerifySsl());
         final HttpResponse<BomProcessingResponse> httpResponse = get(
                 commonConfig.getDependencyTrackBaseUrl() + V1_BOM_TOKEN_UUID)
                 .header("X-Api-Key", commonConfig.getApiKey())

--- a/src/main/java/io/github/pmckeown/dependencytrack/upload/BomClient.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/upload/BomClient.java
@@ -33,10 +33,9 @@ class BomClient {
     @Inject
     BomClient(CommonConfig commonConfig) {
         this.commonConfig = commonConfig;
-    }
-
-    static {
-        Unirest.config().setObjectMapper(new JacksonObjectMapper(relaxedObjectMapper()))
+        Unirest.config()
+                .verifySsl(commonConfig.isValidateCertificationPath())
+                .setObjectMapper(new JacksonObjectMapper(relaxedObjectMapper()))
                 .addDefaultHeader(ACCEPT_ENCODING, "gzip, deflate")
                 .addDefaultHeader(ACCEPT, "application/json");
     }

--- a/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomAction.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomAction.java
@@ -37,6 +37,7 @@ public class UploadBomAction {
     public boolean upload(String bomLocation) throws DependencyTrackException {
         logger.info("Project Name: %s", commonConfig.getProjectName());
         logger.info("Project Version: %s", commonConfig.getProjectVersion());
+        logger.debug("verifySsl when calling DT: %s", commonConfig.isVerifySsl());
         logger.info("%s", commonConfig.getPollingConfig());
 
         Optional<String> encodedBomOptional = bomEncoder.encodeBom(bomLocation, logger);

--- a/src/test/java/io/github/pmckeown/dependencytrack/AbstractDependencyTrackIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/AbstractDependencyTrackIntegrationTest.java
@@ -24,6 +24,7 @@ public abstract class AbstractDependencyTrackIntegrationTest {
                 PROJECT_VERSION,
                 HOST + wireMockRule.port(),
                 API_KEY,
+                true,
                 PollingConfig.disabled());
     }
 

--- a/src/test/java/io/github/pmckeown/dependencytrack/upload/BomClientIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/upload/BomClientIntegrationTest.java
@@ -25,6 +25,8 @@ import static io.github.pmckeown.dependencytrack.TestResourceConstants.V1_BOM_TO
 import static io.github.pmckeown.dependencytrack.TestUtils.asJson;
 import static io.github.pmckeown.dependencytrack.upload.BomProcessingResponseBuilder.aBomProcessingResponse;
 import static io.github.pmckeown.dependencytrack.upload.UploadBomResponseBuilder.anUploadBomResponse;
+import io.github.pmckeown.util.Logger;
+import org.apache.maven.plugin.testing.SilentLog;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -36,7 +38,7 @@ public class BomClientIntegrationTest extends AbstractDependencyTrackIntegration
     private static final String BASE_64_ENCODED_BOM = "blah";
 
     private BomClient client;
-
+    
     @Before
     public void setup() {
         client = new BomClient(getCommonConfig());

--- a/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoIntegrationTest.java
@@ -206,6 +206,7 @@ public class UploadBomMojoIntegrationTest extends AbstractDependencyTrackMojoTes
             uploadBomMojo.setBomLocation(bomLocation);
         }
         uploadBomMojo.setApiKey("ABC123");
+        uploadBomMojo.setVerifySsl(false); 
         return uploadBomMojo;
     }
 }


### PR DESCRIPTION
Hi,

I have my dependency-track properly deployed with https (valid certificates). Problem is all http operations are blocked because java doesn't trust any certificate by default. Without that kind of code it would seem that you would need to keep your truststore always up-to-date with the certificate hosted on your DT server.

I hope you can allow giving an option to skip that certificate validation. Without it I'm just not able to use the plugin.

Best regards