### PR TITLE
Handle empty parent version

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,22 +205,19 @@ Dependency-Track based on the metadata present in the BOM:
 
 From Dependency-Track server 4.8.0 onwards, you can set the project parent by setting `updateParent` to `true`. The 
 parent name will be defaulted to that POM's project parent name. If you wish to override that value, or there is 
-no parent set within the `pom.xml`, then explicitly set `parentName` and `parentVersion`.  
-
-Dependency Track doesn't require a project version to be set which means this will fail if there is no version set on 
-the project in Dependency Track that matches the name of the parent of the maven project or the overridden parentName 
-value.
+no parent set within the `pom.xml`, then explicitly set `parentName` and `parentVersion`. `projectVersion` is optional 
+Dependency-Track, so this has no default to allow for blank values.
 
 **Note:** If the parent cannot be found on the Dependency-Track server, the BOM upload will not be attempted in order to
 prevent a project being incorrectly created or updated the server.
 
-| Property          | Required | Default Value             | Example Values        |
-|-------------------|----------|---------------------------|-----------------------|
-| bomLocation       | false    | target/bom.xml            | target/custom-bom.xml |
-| updateProjectInfo | false    | false                     | false                 |
-| updateParent      | false    | false                     | true                  |
-| parentName        | false    | ${project.parent.name}    | my-name-override      |
-| parentVersion     | false    | ${project.parent.version} | my-version-override   |
+| Property          | Required | Default Value          | Example Values            |
+|-------------------|----------|------------------------|---------------------------|
+| bomLocation       | false    | target/bom.xml         | target/custom-bom.xml     |
+| updateProjectInfo | false    | false                  | false                     |
+| updateParent      | false    | false                  | true                      |
+| parentName        | false    | ${project.parent.name} | my-name-override          |
+| parentVersion     | false    |                        | ${project.parent.version} |
 
 ### Get Project Findings
 After a BOM upload, the best way to determine if there are any vulnerabilities is to use the `findings` goal which is 

--- a/pom.xml
+++ b/pom.xml
@@ -467,7 +467,7 @@
                     <plugin>
                         <groupId>org.cyclonedx</groupId>
                         <artifactId>cyclonedx-maven-plugin</artifactId>
-                        <version>2.7.3</version>
+                        <version>2.7.9</version>
                         <configuration>
                             <schemaVersion>1.4</schemaVersion>
                             <includeBomSerialNumber>true</includeBomSerialNumber>

--- a/src/main/java/io/github/pmckeown/dependencytrack/project/ProjectAction.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/project/ProjectAction.java
@@ -88,10 +88,13 @@ public class ProjectAction {
                 logger.debug("Project UUID: %s", project.getUuid());
                 logger.debug("Patch request: %s", info);
                 Response<Void> response = projectClient.patchProject(project.getUuid(), info);
+                logger.debug("Patch completed without error");
+                logger.debug("Response code: %s", response.getStatus());
+                logger.debug("Success? %s", response.isSuccess());
                 return response.isSuccess();
             } catch (UnirestException ex) {
                 logger.error("Failed to update project info", ex);
-                throw new DependencyTrackException("Failed to update project");
+                throw new DependencyTrackException("Failed to update project", ex);
             }
         }
     }

--- a/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojo.java
@@ -50,14 +50,14 @@ public class UploadBomMojo extends AbstractDependencyTrackMojo {
     @Parameter(defaultValue = "${project.parent.name}", property = "dependency-track.parentName")
     private String parentName;
 
-    @Parameter(defaultValue = "${project.parent.version}", property = "dependency-track.parentVersion")
+    @Parameter(property = "dependency-track.parentVersion")
     private String parentVersion;
 
-    private UploadBomAction uploadBomAction;
+    private final UploadBomAction uploadBomAction;
 
-    private MetricsAction metricsAction;
+    private final MetricsAction metricsAction;
 
-    private ProjectAction projectAction;
+    private final ProjectAction projectAction;
 
     @Inject
     public UploadBomMojo(UploadBomAction uploadBomAction, MetricsAction metricsAction, ProjectAction projectAction,
@@ -111,7 +111,7 @@ public class UploadBomMojo extends AbstractDependencyTrackMojo {
                 return projectAction.getProject(parentName, parentVersion);
             } catch (DependencyTrackException ex) {
                 logger.error("Failed to find parent project with name ['%s-%s']. Check the update parent " +
-                        "settings of your this plugin and verify if a matching parent project exists in the " +
+                        "your settings for this plugin and verify if a matching parent project exists in the " +
                         "server.", parentName, parentVersion);
                 throw ex;
             }


### PR DESCRIPTION
Intended to close issue [375](https://github.com/pmckeown/dependency-track-maven-plugin/issues/375).

The PR allows the Maven plugin to handle project parents with not version, but it causes a potential breaking change as the default goes from `${project.parent.version}` to nothing, if people want a parent version they will now have to explicitly add it.

I am not sure how concerned you are about that change in behaviour.