### PR TITLE
Allowing the skip property to be a little bit more flexible.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ of this plugin:
 | skip                   | false    | false                         |  
 | verifySsl              | false    | true                          |
 
+The skip property has more than two possible values:
+ * true: will skip as usual
+ * releases: will skip if current version of the project is a release
+ * snapshots: will skip if current version of the project is a snapshot
+ * any other values will be considered as false
 
 ## Features
 

--- a/src/test/java/io/github/pmckeown/dependencytrack/finding/FindingsMojoIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/finding/FindingsMojoIntegrationTest.java
@@ -153,7 +153,7 @@ public class FindingsMojoIntegrationTest extends AbstractDependencyTrackMojoTest
                                                 .withVulnerability(aVulnerability().withSeverity(LOW))
                                                 .withAnalysis(anAnalysis())).build()))));
 
-        findingsMojo.setSkip(true);
+        findingsMojo.setSkip("true");
 
         findingsMojo.execute();
 

--- a/src/test/java/io/github/pmckeown/dependencytrack/finding/FindingsMojoTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/finding/FindingsMojoTest.java
@@ -63,7 +63,7 @@ public class FindingsMojoTest {
 
     @Test
     public void thatReportIsNotGeneratedWhenSkipIsTrue() throws Exception {
-        findingsMojo.setSkip(true);
+        findingsMojo.setSkip("true");
 
         findingsMojo.execute();
 

--- a/src/test/java/io/github/pmckeown/dependencytrack/metrics/MetricsMojoIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/metrics/MetricsMojoIntegrationTest.java
@@ -122,7 +122,7 @@ public class MetricsMojoIntegrationTest extends AbstractDependencyTrackMojoTest 
     public void thatTheMetricsIsSkippedWhenSkipIsTrue() throws Exception {
         stubFor(get(urlEqualTo(V1_PROJECT)).willReturn(
                 aResponse().withBodyFile("api/v1/project/get-all-projects.json")));
-        metricsMojo.setSkip(true);
+        metricsMojo.setSkip("true");
         metricsMojo.setProjectName("testName");
         metricsMojo.setProjectVersion("99.99");
 

--- a/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsMojoIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsMojoIntegrationTest.java
@@ -138,7 +138,7 @@ public class PolicyViolationsMojoIntegrationTest extends AbstractDependencyTrack
 
     @Test
     public void thatPolicyViolationsIsSkippedWhenSkipIsTrue() throws Exception {
-        policyMojo.setSkip(true);
+        policyMojo.setSkip("true");
 
         policyMojo.execute();
 

--- a/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsMojoTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsMojoTest.java
@@ -54,7 +54,7 @@ public class PolicyViolationsMojoTest {
 
     @Test
     public void thatReportIsNotGeneratedWhenSkipIsTrue() throws Exception {
-        policyMojo.setSkip(true);
+        policyMojo.setSkip("true");
 
         policyMojo.execute();
 

--- a/src/test/java/io/github/pmckeown/dependencytrack/project/DeleteProjectMojoIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/project/DeleteProjectMojoIntegrationTest.java
@@ -136,7 +136,7 @@ public class DeleteProjectMojoIntegrationTest extends AbstractDependencyTrackMoj
         stubFor(delete(urlPathMatching(V1_PROJECT_UUID)).willReturn(
                 aResponse().withStatus(200)));
 
-        deleteProjectMojo.setSkip(true);
+        deleteProjectMojo.setSkip("true");
 
         deleteProjectMojo.execute();
 

--- a/src/test/java/io/github/pmckeown/dependencytrack/score/ScoreMojoIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/score/ScoreMojoIntegrationTest.java
@@ -196,7 +196,7 @@ public class ScoreMojoIntegrationTest extends AbstractDependencyTrackMojoTest {
         scoreMojo.setDependencyTrackBaseUrl("http://localhost:" + wireMockRule.port());
         scoreMojo.setProjectName("dependency-track");
         scoreMojo.setProjectVersion("3.6.0-SNAPSHOT");
-        scoreMojo.setSkip(true);
+        scoreMojo.setSkip("true");
 
         scoreMojo.execute();
 

--- a/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoIntegrationTest.java
@@ -191,7 +191,7 @@ public class UploadBomMojoIntegrationTest extends AbstractDependencyTrackMojoTes
         stubFor(put(urlEqualTo(ResourceConstants.V1_BOM)).willReturn(ok()));
 
         UploadBomMojo uploadBomMojo = uploadBomMojo("target/test-classes/projects/skip/bom.xml");
-        uploadBomMojo.setSkip(true);
+        uploadBomMojo.setSkip("true");
 
         uploadBomMojo.execute();
 
@@ -201,7 +201,7 @@ public class UploadBomMojoIntegrationTest extends AbstractDependencyTrackMojoTes
     @Test
     public void thatSslVerifyDefaultsToTrue() throws Exception {
         UploadBomMojo uploadBomMojo = uploadBomMojo(BOM_LOCATION);
-        uploadBomMojo.setSkip(true);
+        uploadBomMojo.setSkip("true");
         uploadBomMojo.execute();
         assertThat(Unirest.config().isVerifySsl(), is(true));
     }

--- a/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoTest.java
@@ -77,7 +77,7 @@ public class UploadBomMojoTest {
 
     @Test
     public void thatTheUploadBomIsSkippedWhenSkipIsTrue() throws Exception {
-        uploadBomMojo.setSkip(true);
+        uploadBomMojo.setSkip("true");
         uploadBomMojo.setProjectName(PROJECT_NAME);
         uploadBomMojo.setProjectVersion(PROJECT_VERSION);
 
@@ -85,6 +85,37 @@ public class UploadBomMojoTest {
 
         verify(commonConfig).setProjectName(PROJECT_NAME);
         verify(commonConfig).setProjectVersion(PROJECT_VERSION);
+        verifyNoInteractions(uploadBomAction);
+        verifyNoInteractions(metricsAction);
+        verifyNoInteractions(projectAction);
+    }
+
+    @Test
+    public void thatTheUploadBomIsSkippedWhenSkipIsReleases() throws Exception {
+        uploadBomMojo.setSkip("releases");
+        uploadBomMojo.setProjectName(PROJECT_NAME);
+        uploadBomMojo.setProjectVersion(PROJECT_VERSION);
+
+        uploadBomMojo.execute();
+
+        verify(commonConfig).setProjectName(PROJECT_NAME);
+        verify(commonConfig).setProjectVersion(PROJECT_VERSION);
+        verifyNoInteractions(uploadBomAction);
+        verifyNoInteractions(metricsAction);
+        verifyNoInteractions(projectAction);
+    }
+
+    @Test
+    public void thatTheUploadBomIsSkippedWhenSkipIsSnapshots() throws Exception {
+        String snapshotVersion = "1.0-SNAPSHOT";
+        uploadBomMojo.setSkip("snapshots");
+        uploadBomMojo.setProjectName(PROJECT_NAME);
+        uploadBomMojo.setProjectVersion(snapshotVersion);
+
+        uploadBomMojo.execute();
+
+        verify(commonConfig).setProjectName(PROJECT_NAME);
+        verify(commonConfig).setProjectVersion(snapshotVersion);
         verifyNoInteractions(uploadBomAction);
         verifyNoInteractions(metricsAction);
         verifyNoInteractions(projectAction);


### PR DESCRIPTION
Hi,
some developers approached me and asked that only releases should be uploaded to dependencytrack.
You can of course do a lot with the maven build helper plugins. But I find the solution in the plugin much cleaner. The solution is based on the behavior of the [maven-deploy-plugin](https://maven.apache.org/plugins/maven-deploy-plugin/deploy-mojo.html#skip).

I would be very grateful for any feedback.