### PR TITLE
Implement isLatest for Dependency BOM Upload API

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ prevent a project being incorrectly created or updated the server.
 | updateParent      | false    | false                  | true                      |
 | parentName        | false    | ${project.parent.name} | my-name-override          |
 | parentVersion     | false    |                        | ${project.parent.version} |
+| isLatest          | false    | false                  | true                      |
 
 ### Get Project Findings
 After a BOM upload, the best way to determine if there are any vulnerabilities is to use the `findings` goal which is 

--- a/pom.xml
+++ b/pom.xml
@@ -80,17 +80,17 @@
         <dependency>
             <groupId>com.konghq</groupId>
             <artifactId>unirest-objectmapper-jackson</artifactId>
-            <version>3.14.2</version>
+            <version>3.14.5</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.15.2</version>
+            <version>2.17.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.14.2</version>
+            <version>2.17.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -163,7 +163,7 @@
         <dependency>
             <groupId>org.cyclonedx</groupId>
             <artifactId>cyclonedx-core-java</artifactId>
-            <version>7.3.2</version>
+            <version>9.0.4</version>
         </dependency>
 
         <!-- Test dependencies -->

--- a/src/main/java/io/github/pmckeown/dependencytrack/bom/BomParser.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/bom/BomParser.java
@@ -4,14 +4,14 @@ import io.github.pmckeown.dependencytrack.project.ProjectInfo;
 import io.github.pmckeown.util.Logger;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.BOMInputStream;
-import org.cyclonedx.BomParserFactory;
+
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.model.Component;
+import org.cyclonedx.parsers.BomParserFactory;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.io.File;
-import java.io.FileInputStream;
 import java.util.Optional;
 
 /**
@@ -41,11 +41,11 @@ public class BomParser {
      */
     public Optional<ProjectInfo> getProjectInfo(File bomFile) {
         if (!bomFile.canRead()) {
+            logger.warn("Can not read bom {}", bomFile);
             return Optional.empty();
         }
         Bom bom;
-        try {
-            BOMInputStream bis = new BOMInputStream(new FileInputStream(bomFile), false);
+        try (BOMInputStream bis = BOMInputStream.builder().setFile(bomFile).setInclude(false).get()) {
             byte[] bytes = IOUtils.toByteArray(bis);
             bom = BomParserFactory.createParser(bytes).parse(bytes);
         } catch (Exception ex) {

--- a/src/main/java/io/github/pmckeown/dependencytrack/project/Project.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/project/Project.java
@@ -16,14 +16,19 @@ public class Project extends Item {
     private String name;
     private String version;
     private Metrics metrics;
+    private boolean isLatest;
 
     @JsonCreator
-    public Project(@JsonProperty("uuid") String uuid, @JsonProperty("name") String name,
-               @JsonProperty("version") String version, @JsonProperty("metrics") Metrics metrics) {
+    public Project(@JsonProperty("uuid") String uuid,
+                   @JsonProperty("name") String name,
+                   @JsonProperty("version") String version,
+                   @JsonProperty("metrics") Metrics metrics,
+                   @JsonProperty("isLatest") boolean isLatest) {
         super(uuid);
         this.name = name;
         this.version = version;
         this.metrics = metrics;
+        this.isLatest = isLatest;
     }
 
     public String getName() {
@@ -36,6 +41,10 @@ public class Project extends Item {
 
     public Metrics getMetrics() {
         return metrics;
+    }
+
+    public boolean isLatest() {
+        return isLatest;
     }
 
     @Override

--- a/src/main/java/io/github/pmckeown/dependencytrack/project/ProjectAction.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/project/ProjectAction.java
@@ -65,6 +65,7 @@ public class ProjectAction {
             Optional<ProjectInfo> optInfo = bomParser.getProjectInfo(new File(updateReq.getBomLocation()));
             if (optInfo.isPresent()) {
                 info = optInfo.get();
+                info.setIsLatest(Boolean.valueOf(project.isLatest()));
             } else {
                 logger.warn("Could not create ProjectInfo from bom at location: %s", updateReq.getBomLocation());
                 return false;

--- a/src/main/java/io/github/pmckeown/dependencytrack/project/ProjectInfo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/project/ProjectInfo.java
@@ -18,6 +18,7 @@ public class ProjectInfo {
     private String purl;
     private String cpe;
     private String swidTagId;
+    private Boolean isLatest;
     private Item parent;
 
     public String getAuthor() {
@@ -90,6 +91,14 @@ public class ProjectInfo {
 
     public void setParent(Item parent) {
         this.parent = parent;
+    }
+
+    public Boolean getIsLatest() {
+        return isLatest;
+    }
+
+    public void setIsLatest(Boolean isLatest) {
+        this.isLatest = isLatest;
     }
 
     @Override

--- a/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomAction.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomAction.java
@@ -35,6 +35,10 @@ public class UploadBomAction {
     }
 
     public boolean upload(String bomLocation) throws DependencyTrackException {
+        return upload(bomLocation, false);
+    }
+
+    public boolean upload(String bomLocation, boolean isLatest) throws DependencyTrackException {
         logger.info("Project Name: %s", commonConfig.getProjectName());
         logger.info("Project Version: %s", commonConfig.getProjectVersion());
         logger.info("%s", commonConfig.getPollingConfig());
@@ -45,7 +49,7 @@ public class UploadBomAction {
             return false;
         }
 
-        Optional<UploadBomResponse> uploadBomResponse = doUpload(encodedBomOptional.get());
+        Optional<UploadBomResponse> uploadBomResponse = doUpload(encodedBomOptional.get(), isLatest);
 
         if (commonConfig.getPollingConfig().isEnabled() && uploadBomResponse.isPresent()) {
             try {
@@ -74,11 +78,15 @@ public class UploadBomAction {
         });
     }
 
-    private Optional<UploadBomResponse> doUpload(String encodedBom) throws DependencyTrackException {
+    private Optional<UploadBomResponse> doUpload(String encodedBom, boolean isLatest) throws DependencyTrackException {
         try {
-            Response<UploadBomResponse> response = bomClient.uploadBom(new UploadBomRequest(
-                    commonConfig.getProjectName(), commonConfig.getProjectVersion(), true, encodedBom));
-            
+            Response<UploadBomResponse> response = bomClient.uploadBom(
+                new UploadBomRequest(commonConfig.getProjectName(),
+                                     commonConfig.getProjectVersion(),
+                                     true,
+                                     encodedBom,
+                                     isLatest));
+
             if (response.isSuccess()) {
                 logger.info("BOM uploaded to Dependency Track server");
                 return response.getBody();

--- a/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojo.java
@@ -53,6 +53,9 @@ public class UploadBomMojo extends AbstractDependencyTrackMojo {
     @Parameter(property = "dependency-track.parentVersion")
     private String parentVersion;
 
+    @Parameter(property = "dependency-track.isLatest", defaultValue = "false")
+    private boolean isLatest;
+
     private final UploadBomAction uploadBomAction;
 
     private final MetricsAction metricsAction;
@@ -73,7 +76,7 @@ public class UploadBomMojo extends AbstractDependencyTrackMojo {
         logger.info("Update Project Parent : %s", updateParent);
 
         try {
-            if (!uploadBomAction.upload(getBomLocation())) {
+            if (!uploadBomAction.upload(getBomLocation(), isLatest)) {
                 handleFailure("Bom upload failed");
             }
             Project project = projectAction.getProject(projectName, projectVersion);
@@ -149,6 +152,10 @@ public class UploadBomMojo extends AbstractDependencyTrackMojo {
 
     void setParentVersion(String parentVersion) {
         this.parentVersion = parentVersion;
+    }
+
+    void setLatest(boolean isLatest) {
+        this.isLatest = isLatest;
     }
 
 }

--- a/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomRequest.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomRequest.java
@@ -10,16 +10,18 @@ import org.apache.commons.lang3.builder.ToStringStyle;
  */
 public class UploadBomRequest {
 
-    private String projectName;
-    private String projectVersion;
-    private boolean autoCreate;
-    private String base64EncodedBom;
+    private final String projectName;
+    private final String projectVersion;
+    private final boolean autoCreate;
+    private final String base64EncodedBom;
+    private final boolean isLatest;
 
-    UploadBomRequest(String projectName, String projectVersion, boolean autoCreate, String base64EncodedBom) {
+    UploadBomRequest(String projectName, String projectVersion, boolean autoCreate, String base64EncodedBom, boolean isLatest) {
         this.projectName = projectName;
         this.projectVersion = projectVersion;
         this.autoCreate = autoCreate;
         this.base64EncodedBom = base64EncodedBom;
+        this.isLatest = isLatest;
     }
 
     public String getProjectName() {
@@ -34,10 +36,20 @@ public class UploadBomRequest {
         return autoCreate;
     }
 
+    /**
+     * TODO: Change method name to IsisLatest, when switching to post upload request
+     *
+     * @return
+     */
+    public boolean isIsLatestProjectVersion() {
+        return isLatest;
+    }
+
     public String getBom() {
         return base64EncodedBom;
     }
 
+    @Override
     public String toString() {
         return ToStringBuilder.reflectionToString(this, ToStringStyle.JSON_STYLE);
     }

--- a/src/test/java/io/github/pmckeown/dependencytrack/ObjectMapperFactoryTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/ObjectMapperFactoryTest.java
@@ -8,6 +8,7 @@ import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static org.junit.Assert.assertNotNull;
@@ -19,7 +20,7 @@ public class ObjectMapperFactoryTest {
         JacksonObjectMapper om = new JacksonObjectMapper(ObjectMapperFactory.relaxedObjectMapper());
 
         List<Project> projects = om.readValue(IOUtils.toString(FileUtils.openInputStream(
-                new File("src/test/resources/__files/api/v1/project/get-all-projects.json"))),
+                new File("src/test/resources/__files/api/v1/project/get-all-projects.json")), StandardCharsets.UTF_8),
                 new GenericType<List<Project>>(){});
 
         assertNotNull(projects);

--- a/src/test/java/io/github/pmckeown/dependencytrack/project/ProjectActionTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/project/ProjectActionTest.java
@@ -171,16 +171,40 @@ public class ProjectActionTest {
         }
     }
 
+    @Test
+    public void thatWhenProjectBomAndIsLatestTrueIsProvidedNoExceptionIsReturned() throws Exception {
+        doReturn(Optional.of(new ProjectInfo())).when(bomParser).getProjectInfo(any(File.class));
+        doReturn(aSuccessResponse().build()).when(projectClient).patchProject(anyString(), any(ProjectInfo.class));
+
+        UpdateRequest updateReq = new UpdateRequest();
+        updateReq.withBomLocation(String.valueOf(new File(BomParser.class.getResource("bom.xml").getPath())));
+        assertTrue(projectAction.updateProject(project3(), updateReq));
+    }
+
+    @Test
+    public void thatWhenProjectBomAndIsLatestFalseIsProvidedNoExceptionIsReturned() throws Exception {
+        doReturn(Optional.of(new ProjectInfo())).when(bomParser).getProjectInfo(any(File.class));
+        doReturn(aSuccessResponse().build()).when(projectClient).patchProject(anyString(), any(ProjectInfo.class));
+
+        UpdateRequest updateReq = new UpdateRequest();
+        updateReq.withBomLocation(String.valueOf(new File(BomParser.class.getResource("bom.xml").getPath())));
+        assertTrue(projectAction.updateProject(project1(), updateReq));
+    }
+
     private Response aNotFoundResponse() {
         return new Response(404, "Not Found", false);
     }
 
     private Project project1() {
-        return new Project(UUID_2, PROJECT_NAME_2, PROJECT_VERSION_2, null);
+        return new Project(UUID_2, PROJECT_NAME_2, PROJECT_VERSION_2, null, false);
     }
 
     private Project project2() {
-        return new Project(UUID_2, PROJECT_NAME_2, PROJECT_VERSION_2, null);
+        return new Project(UUID_2, PROJECT_NAME_2, PROJECT_VERSION_2, null, false);
+    }
+
+    private Project project3() {
+        return new Project(UUID_2, PROJECT_NAME_2, PROJECT_VERSION_2, null, true);
     }
 
     private List<Project> aProjectList() {

--- a/src/test/java/io/github/pmckeown/dependencytrack/project/ProjectBuilder.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/project/ProjectBuilder.java
@@ -11,6 +11,7 @@ public class ProjectBuilder {
     private String name = "test-project";
     private String version = "2.0.0";
     private Metrics metrics;
+    private boolean isLatest;
 
     public static ProjectBuilder aProject() {
         return new ProjectBuilder();
@@ -36,7 +37,12 @@ public class ProjectBuilder {
         return this;
     }
 
+    public ProjectBuilder withIsLatest(boolean isLatest) {
+        this.isLatest = isLatest;
+        return this;
+    }
+
     public Project build() {
-        return new Project(uuid, name, version, metrics);
+        return new Project(uuid, name, version, metrics, isLatest);
     }
 }

--- a/src/test/java/io/github/pmckeown/dependencytrack/upload/BomClientIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/upload/BomClientIntegrationTest.java
@@ -36,7 +36,7 @@ public class BomClientIntegrationTest extends AbstractDependencyTrackIntegration
     private static final String BASE_64_ENCODED_BOM = "blah";
 
     private BomClient client;
-    
+
     @Before
     public void setup() {
         client = new BomClient(getCommonConfig());
@@ -119,6 +119,6 @@ public class BomClientIntegrationTest extends AbstractDependencyTrackIntegration
      */
 
     private UploadBomRequest aBom() {
-        return new UploadBomRequest(PROJECT_NAME, PROJECT_VERSION, false, BASE_64_ENCODED_BOM);
+        return new UploadBomRequest(PROJECT_NAME, PROJECT_VERSION, false, BASE_64_ENCODED_BOM, false);
     }
 }

--- a/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoIntegrationTest.java
@@ -171,6 +171,22 @@ public class UploadBomMojoIntegrationTest extends AbstractDependencyTrackMojoTes
     }
 
     @Test
+    public void thatProjectIsLatestCanBeProvided() throws Exception {
+        stubFor(get(urlPathMatching(V1_PROJECT)).willReturn(
+                aResponse().withBodyFile("api/v1/project/get-all-projects.json")));
+        stubFor(put(urlEqualTo(V1_BOM)).willReturn(ok()));
+
+
+        UploadBomMojo uploadBomMojo = uploadBomMojo(BOM_LOCATION);
+        uploadBomMojo.setLatest(true);
+        uploadBomMojo.execute();
+
+        verify(exactly(1), putRequestedFor(urlEqualTo(V1_BOM))
+                .withRequestBody(
+                        matchingJsonPath("$.isLatestProjectVersion", equalTo("true"))));
+    }
+
+    @Test
     public void thatProjectVersionDefaultsToPomVersion() throws Exception {
         stubFor(get(urlPathMatching(V1_PROJECT)).willReturn(
                 aResponse().withBodyFile("api/v1/project/get-all-projects.json")));

--- a/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
@@ -63,16 +64,18 @@ public class UploadBomMojoTest {
     @Test
     public void thatTheBomLocationIsDefaultedWhenNotSupplied() throws Exception {
         ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Boolean> argumentCaptor2 = ArgumentCaptor.forClass(Boolean.class);
         doReturn(new File(".")).when(project).getBasedir();
         doReturn(aProject().build()).when(projectAction).getProject(PROJECT_NAME, PROJECT_VERSION);
-        doReturn(true).when(uploadBomAction).upload(anyString());
+        doReturn(true).when(uploadBomAction).upload(anyString(), anyBoolean());
 
         uploadBomMojo.setProjectName(PROJECT_NAME);
         uploadBomMojo.setProjectVersion(PROJECT_VERSION);
         uploadBomMojo.execute();
 
-        verify(uploadBomAction).upload(argumentCaptor.capture());
+        verify(uploadBomAction).upload(argumentCaptor.capture(), argumentCaptor2.capture());
         assertThat(argumentCaptor.getValue(), is(equalTo("./target/bom.xml")));
+        assertThat(argumentCaptor2.getValue(), is(equalTo(false)));
     }
 
     @Test
@@ -137,7 +140,7 @@ public class UploadBomMojoTest {
 
     @Test
     public void thatWhenUpdateParentFailsTheLoggerIsCalledAndBuildFails() throws Exception {
-        doReturn(true).when(uploadBomAction).upload(anyString());
+        doReturn(true).when(uploadBomAction).upload(anyString(), anyBoolean());
         doReturn(aProject().withName("project-parent").withVersion("1.2.3").build())
                 .when(projectAction).getProject("project-parent", "1.2.3");
 
@@ -157,7 +160,7 @@ public class UploadBomMojoTest {
 
     @Test
     public void thatUpdateParentFailsWhenParentNameIsNull() throws Exception {
-        doReturn(true).when(uploadBomAction).upload(anyString());
+        doReturn(true).when(uploadBomAction).upload(anyString(), anyBoolean());
 
         uploadBomMojo.setParentName(null);
         uploadBomMojo.setParentVersion(null);


### PR DESCRIPTION
The Bom upload parameter isLatestProjectVersion was recently introduced. This pull request makes the parameter usable during Maven execution.
I noticed that during the project update the flag was reset, possibly a bug in DependencyTrack, so it is necessary to add this flag during the project update.