### PR TITLE
Build a JDK-8 Jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <maven.version>3.9.5</maven.version>
     </properties>
 


### PR DESCRIPTION
Hi @pmckeown,
thanks for merging me previous Pull-Request.

I have seen that you had problems with the Sonar plugin and have therefore raised the JDK.
Can you please continue to build and deliver a JDK-8 JAR. I know that JDK-8 is quite old now, but it is still supported https://endoflife.date/eclipse-temurin . Maven 3 also supports JDK-8. https://maven.apache.org/download.cgi
There are also projects in my company that do not yet support JDK 17 and I would also like to run the plugin there with a JDK-8.