### PR TITLE
Consolidate upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ The Automation team needs the following permissions:
 * In Dependency Track v4.4.x and later: 
   * BOM_UPLOAD
   * PORTFOLIO_MANAGEMENT
+    Only when project should be automatically created. If a project exists in any version, this permission is not needed.
   * PROJECT_CREATION_UPLOAD
   * VIEW_PORTFOLIO
   * VIEW_VULNERABILITY

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ The Automation team needs the following permissions:
 * In Dependency Track v4.4.x and later: 
   * BOM_UPLOAD
   * PORTFOLIO_MANAGEMENT
+  
     Only when project should be automatically created. If a project exists in any version, this permission is not needed.
   * PROJECT_CREATION_UPLOAD
   * VIEW_PORTFOLIO

--- a/README.md
+++ b/README.md
@@ -218,15 +218,16 @@ Dependency-Track, so this has no default to allow for blank values.
 **Note:** If the parent cannot be found on the Dependency-Track server, the BOM upload will not be attempted in order to
 prevent a project being incorrectly created or updated the server.
 
-| Property             | Required | Default Value          | Example Values            |
-|----------------------|----------|------------------------|---------------------------|
-| bomLocation          | false    | target/bom.xml         | target/custom-bom.xml     |
-| updateProjectInfo    | false    | false                  | false                     |
-| updateParent         | false    | false                  | true                      |
-| parentName           | false    | ${project.parent.name} | my-name-override          |
-| parentVersion        | false    |                        | ${project.parent.version} |
-| isLatest             | false    | false                  | true                      |
-| projectTags[].name   | false    | false                  | <name>tag1</name>         |
+| Property           | Required | Default Value          | Example Values                        |
+|--------------------|----------|------------------------|---------------------------------------|
+| bomLocation        | false    | target/bom.xml         | target/custom-bom.xml                 |
+| updateProjectInfo  | false    | false                  | false                                 |
+| updateParent       | false    | false                  | true                                  |
+| parentUuid         | false    |                        | 628df5eb-a7fe-4c3f-831c-4536839a05ed  |
+| parentName         | false    | ${project.parent.name} | my-name-override                      |
+| parentVersion      | false    |                        | ${project.parent.version}             |
+| isLatest           | false    | false                  | true                                  |
+| projectTags[].name | false    | false                  | <name>tag1</name>                     |
 
 The `isLatest` option sets the flag on the project to indicate that it is the latest version.
 

--- a/README.md
+++ b/README.md
@@ -215,8 +215,9 @@ parent name will be defaulted to that POM's project parent name. If you wish to 
 no parent set within the `pom.xml`, then explicitly set `parentName` and `parentVersion`. `projectVersion` is optional 
 Dependency-Track, so this has no default to allow for blank values.
 
-**Note:** If the parent cannot be found on the Dependency-Track server, the BOM upload will not be attempted in order to
-prevent a project being incorrectly created or updated the server.
+**Note 1:** If both `parentUuid` and `parentName` / `parentVersion` are provided in configuration `parentUuid` will take precedence.
+
+**Note 2:** If a non-existing parent information is provided, the plugin will fail with `404 Not found`. 
 
 | Property           | Required | Default Value          | Example Values                        |
 |--------------------|----------|------------------------|---------------------------------------|

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.pmckeown</groupId>
     <artifactId>dependency-track-maven-plugin</artifactId>
-    <version>1.8.0</version>
+    <version>1.8.1-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>Dependency Track Maven Plugin</name>
@@ -383,15 +383,14 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <!-- https://central.sonatype.org/publish/publish-portal-maven/ -->
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.13</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.6.0</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <publishingServerId>central</publishingServerId>
                         </configuration>
                     </plugin>
                     <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.github.pmckeown</groupId>
     <artifactId>dependency-track-maven-plugin</artifactId>
-    <version>1.7.2-SNAPSHOT</version>
+    <version>1.8.0</version>
     <packaging>maven-plugin</packaging>
 
     <name>Dependency Track Maven Plugin</name>

--- a/src/main/java/io/github/pmckeown/dependencytrack/AbstractDependencyTrackMojo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/AbstractDependencyTrackMojo.java
@@ -32,6 +32,9 @@ import static kong.unirest.HeaderNames.ACCEPT_ENCODING;
  */
 public abstract class AbstractDependencyTrackMojo extends AbstractMojo {
 
+    @Parameter(required = false, property = "dependency-track.projectUuid")
+    protected String projectUuid;
+
     @Parameter(required = true, defaultValue = "${project.artifactId}", property = "dependency-track.projectName")
     protected String projectName;
 

--- a/src/main/java/io/github/pmckeown/dependencytrack/AbstractDependencyTrackMojo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/AbstractDependencyTrackMojo.java
@@ -31,9 +31,6 @@ import static kong.unirest.HeaderNames.ACCEPT_ENCODING;
  */
 public abstract class AbstractDependencyTrackMojo extends AbstractMojo {
 
-    @Parameter(required = false, property = "dependency-track.projectUuid")
-    protected String projectUuid;
-
     @Parameter(required = true, defaultValue = "${project.artifactId}", property = "dependency-track.projectName")
     protected String projectName;
 

--- a/src/main/java/io/github/pmckeown/dependencytrack/AbstractDependencyTrackMojo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/AbstractDependencyTrackMojo.java
@@ -13,7 +13,6 @@ import org.apache.maven.plugins.annotations.Parameter;
 import static io.github.pmckeown.dependencytrack.ObjectMapperFactory.relaxedObjectMapper;
 import static kong.unirest.HeaderNames.ACCEPT;
 import static kong.unirest.HeaderNames.ACCEPT_ENCODING;
-
 /**
  * Base class for Mojos in this project.
  *

--- a/src/main/java/io/github/pmckeown/dependencytrack/CommonConfig.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/CommonConfig.java
@@ -1,8 +1,13 @@
 package io.github.pmckeown.dependencytrack;
 
+import io.github.pmckeown.util.Logger;
 import java.util.Collections;
 import java.util.Set;
+import javax.inject.Inject;
 import javax.inject.Singleton;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.maven.plugin.logging.SystemStreamLog;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
@@ -29,9 +34,7 @@ public class CommonConfig {
     private boolean autoCreate = true;
     private Set<String> projectTags = Collections.emptySet();
 
-    public CommonConfig() {
-        // For dependency injection
-    }
+    protected Logger logger = new Logger(new SystemStreamLog());
 
     public String getProjectName() {
         return projectName;
@@ -128,13 +131,19 @@ public class CommonConfig {
         this.mavenProject = mavenProject;
     }
 
-    public String getBomLocation() {
-        return bomLocation;
-    }
-
     public void setBomLocation(String bomLocation) {
         this.bomLocation = bomLocation;
     }
+    public String getBomLocation() {
+        if (StringUtils.isNotBlank(bomLocation)) {
+            return bomLocation;
+        } else {
+            String defaultLocation = mavenProject.getBasedir() + "/target/bom.xml";
+            this.logger.debug("bomLocation not supplied so using: %s", defaultLocation);
+            return defaultLocation;
+        }
+    }
+
     public boolean isAutoCreate() {
         return autoCreate;
     }

--- a/src/main/java/io/github/pmckeown/dependencytrack/CommonConfig.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/CommonConfig.java
@@ -1,6 +1,10 @@
 package io.github.pmckeown.dependencytrack;
 
+import java.util.Collections;
+import java.util.Set;
 import javax.inject.Singleton;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
 
 /**
  * Holder for common configuration supplied on Mojo execution
@@ -15,6 +19,15 @@ public class CommonConfig {
     private String dependencyTrackBaseUrl;
     private String apiKey;
     private PollingConfig pollingConfig;
+    private String bomLocation;
+    private MavenProject mavenProject;
+    private boolean updateProjectInfo;
+    private boolean updateParent;
+    private String parentName;
+    private String parentVersion;
+    private boolean isLatest;
+    private boolean autoCreate = true;
+    private Set<String> projectTags = Collections.emptySet();
 
     public CommonConfig() {
         // For dependency injection
@@ -59,5 +72,70 @@ public class CommonConfig {
     public void setPollingConfig(PollingConfig pollingConfig) {
         this.pollingConfig = pollingConfig;
     }
+    public Set<String> getProjectTags() {
+        return projectTags;
+    }
 
+    public void setProjectTags(Set<String> projectTags) {
+        this.projectTags = projectTags;
+    }
+
+    public boolean isLatest() {
+        return isLatest;
+    }
+
+    public void setLatest(boolean latest) {
+        isLatest = latest;
+    }
+
+    public String getParentVersion() {
+        return parentVersion;
+    }
+
+    public void setParentVersion(String parentVersion) {
+        this.parentVersion = parentVersion;
+    }
+
+    public String getParentName() {
+        return parentName;
+    }
+
+    public void setParentName(String parentName) {
+        this.parentName = parentName;
+    }
+
+    public boolean isUpdateParent() {
+        return updateParent;
+    }
+
+    public void setUpdateParent(boolean updateParent) {
+        this.updateParent = updateParent;
+    }
+
+    public boolean isUpdateProjectInfo() {
+        return updateProjectInfo;
+    }
+
+    public void setUpdateProjectInfo(boolean updateProjectInfo) {
+        this.updateProjectInfo = updateProjectInfo;
+    }
+
+    public MavenProject getMavenProject() {
+        return mavenProject;
+    }
+
+    public void setMavenProject(MavenProject mavenProject) {
+        this.mavenProject = mavenProject;
+    }
+
+    public String getBomLocation() {
+        return bomLocation;
+    }
+
+    public void setBomLocation(String bomLocation) {
+        this.bomLocation = bomLocation;
+    }
+    public boolean isAutoCreate() {
+        return autoCreate;
+    }
 }

--- a/src/main/java/io/github/pmckeown/dependencytrack/CommonConfig.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/CommonConfig.java
@@ -3,7 +3,6 @@ package io.github.pmckeown.dependencytrack;
 import io.github.pmckeown.util.Logger;
 import java.util.Collections;
 import java.util.Set;
-import java.util.UUID;
 import javax.inject.Singleton;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.logging.SystemStreamLog;

--- a/src/main/java/io/github/pmckeown/dependencytrack/CommonConfig.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/CommonConfig.java
@@ -3,12 +3,10 @@ package io.github.pmckeown.dependencytrack;
 import io.github.pmckeown.util.Logger;
 import java.util.Collections;
 import java.util.Set;
-import javax.inject.Inject;
+import java.util.UUID;
 import javax.inject.Singleton;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.logging.Log;
 import org.apache.maven.plugin.logging.SystemStreamLog;
-import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
 /**
@@ -19,6 +17,7 @@ import org.apache.maven.project.MavenProject;
 @Singleton
 public class CommonConfig {
 
+    private UUID projectUuid;
     private String projectName;
     private String projectVersion;
     private String dependencyTrackBaseUrl;
@@ -28,6 +27,7 @@ public class CommonConfig {
     private MavenProject mavenProject;
     private boolean updateProjectInfo;
     private boolean updateParent;
+    private UUID parentUuid;
     private String parentName;
     private String parentVersion;
     private boolean isLatest;
@@ -35,6 +35,10 @@ public class CommonConfig {
     private Set<String> projectTags = Collections.emptySet();
 
     protected Logger logger = new Logger(new SystemStreamLog());
+
+    public UUID getProjectUuid() { return projectUuid; }
+
+    public void setProjectUuid(UUID projectUuid) { this.projectUuid = projectUuid; }
 
     public String getProjectName() {
         return projectName;
@@ -99,6 +103,11 @@ public class CommonConfig {
         this.parentVersion = parentVersion;
     }
 
+
+    public UUID getParentUuid() { return parentUuid; }
+
+    public void setParentUuid(UUID parentUuid) { this.parentUuid = parentUuid; }
+
     public String getParentName() {
         return parentName;
     }
@@ -107,25 +116,17 @@ public class CommonConfig {
         this.parentName = parentName;
     }
 
-    public boolean isUpdateParent() {
-        return updateParent;
-    }
+    public boolean isUpdateParent() { return updateParent; }
 
     public void setUpdateParent(boolean updateParent) {
         this.updateParent = updateParent;
     }
 
-    public boolean isUpdateProjectInfo() {
-        return updateProjectInfo;
-    }
+    public boolean isUpdateProjectInfo() { return updateProjectInfo; }
 
-    public void setUpdateProjectInfo(boolean updateProjectInfo) {
-        this.updateProjectInfo = updateProjectInfo;
-    }
+    public void setUpdateProjectInfo(boolean updateProjectInfo) { this.updateProjectInfo = updateProjectInfo; }
 
-    public MavenProject getMavenProject() {
-        return mavenProject;
-    }
+    public MavenProject getMavenProject() { return mavenProject; }
 
     public void setMavenProject(MavenProject mavenProject) {
         this.mavenProject = mavenProject;
@@ -138,7 +139,7 @@ public class CommonConfig {
         if (StringUtils.isNotBlank(bomLocation)) {
             return bomLocation;
         } else {
-            String defaultLocation = mavenProject.getBasedir() + "/target/bom.xml";
+            String defaultLocation = getMavenProject().getBasedir() + "/target/bom.xml";
             this.logger.debug("bomLocation not supplied so using: %s", defaultLocation);
             return defaultLocation;
         }

--- a/src/main/java/io/github/pmckeown/dependencytrack/CommonConfig.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/CommonConfig.java
@@ -17,7 +17,6 @@ import org.apache.maven.project.MavenProject;
 @Singleton
 public class CommonConfig {
 
-    private UUID projectUuid;
     private String projectName;
     private String projectVersion;
     private String dependencyTrackBaseUrl;
@@ -27,7 +26,7 @@ public class CommonConfig {
     private MavenProject mavenProject;
     private boolean updateProjectInfo;
     private boolean updateParent;
-    private UUID parentUuid;
+    private String parentUuid;
     private String parentName;
     private String parentVersion;
     private boolean isLatest;
@@ -35,10 +34,6 @@ public class CommonConfig {
     private Set<String> projectTags = Collections.emptySet();
 
     protected Logger logger = new Logger(new SystemStreamLog());
-
-    public UUID getProjectUuid() { return projectUuid; }
-
-    public void setProjectUuid(UUID projectUuid) { this.projectUuid = projectUuid; }
 
     public String getProjectName() {
         return projectName;
@@ -104,9 +99,9 @@ public class CommonConfig {
     }
 
 
-    public UUID getParentUuid() { return parentUuid; }
+    public String getParentUuid() { return parentUuid; }
 
-    public void setParentUuid(UUID parentUuid) { this.parentUuid = parentUuid; }
+    public void setParentUuid(String parentUuid) { this.parentUuid = parentUuid; }
 
     public String getParentName() {
         return parentName;

--- a/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomAction.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomAction.java
@@ -12,7 +12,6 @@ import javax.inject.Singleton;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Optional;
-import java.util.Set;
 
 /**
  * Handles uploading BOMs

--- a/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomAction.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomAction.java
@@ -11,7 +11,6 @@ import javax.inject.Singleton;
 
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
@@ -55,8 +54,7 @@ public class UploadBomAction {
             return false;
         }
 
-        Optional<UploadBomResponse> uploadBomResponse = doUpload(encodedBomOptional.get(),
-            commonConfig.isLatest(), commonConfig.getProjectTags());
+        Optional<UploadBomResponse> uploadBomResponse = doUpload(encodedBomOptional.get());
 
         if (commonConfig.getPollingConfig().isEnabled() && uploadBomResponse.isPresent()) {
             try {
@@ -85,7 +83,7 @@ public class UploadBomAction {
         });
     }
 
-    private Optional<UploadBomResponse> doUpload(String encodedBom, boolean isLatest, Set<String> projectTags) throws DependencyTrackException {
+    private Optional<UploadBomResponse> doUpload(String encodedBom) throws DependencyTrackException {
         try {
             Response<UploadBomResponse> response = bomClient.uploadBom(
                 new UploadBomRequest(commonConfig,

--- a/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomAction.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomAction.java
@@ -42,6 +42,7 @@ public class UploadBomAction {
         logger.info("Project Version: %s", commonConfig.getProjectVersion());
         logger.info("Project is latest: %s", commonConfig.isLatest());
         logger.info("Project Tags: %s", StringUtils.join(commonConfig.getProjectTags(), ","));
+        logger.info("Parent UUID: %s", commonConfig.getParentUuid());
         logger.info("Parent Name: %s", commonConfig.getParentName());
         logger.info("Parent Version: %s", commonConfig.getParentVersion());
         logger.info("%s", commonConfig.getPollingConfig());
@@ -85,9 +86,7 @@ public class UploadBomAction {
     private Optional<UploadBomResponse> doUpload(String encodedBom) throws DependencyTrackException {
         try {
             Response<UploadBomResponse> response = bomClient.uploadBom(
-                new UploadBomRequest(commonConfig,
-                                     encodedBom
-                )
+                new UploadBomRequest(commonConfig, encodedBom)
             );
 
             if (response.isSuccess()) {

--- a/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomAction.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomAction.java
@@ -39,24 +39,24 @@ public class UploadBomAction {
         this.logger = logger;
     }
 
-    public boolean upload(String bomLocation) throws DependencyTrackException {
-        return upload(bomLocation, false, Collections.emptySet());
-    }
-
-    public boolean upload(String bomLocation, boolean isLatest, Set<String> projectTags) throws DependencyTrackException {
+    public boolean upload() throws DependencyTrackException {
         logger.info("Project Name: %s", commonConfig.getProjectName());
         logger.info("Project Version: %s", commonConfig.getProjectVersion());
-        logger.info("Project Tags: %s", StringUtils.join(projectTags, ","));
+        logger.info("Project is latest: %s", commonConfig.isLatest());
+        logger.info("Project Tags: %s", StringUtils.join(commonConfig.getProjectTags(), ","));
+        logger.info("Parent Name: %s", commonConfig.getParentName());
+        logger.info("Parent Version: %s", commonConfig.getParentVersion());
         logger.info("%s", commonConfig.getPollingConfig());
 
 
-        Optional<String> encodedBomOptional = bomEncoder.encodeBom(bomLocation, logger);
+        Optional<String> encodedBomOptional = bomEncoder.encodeBom(commonConfig.getBomLocation(), logger);
         if (!encodedBomOptional.isPresent()) {
-            logger.error("No bom.xml could be located at: %s", bomLocation);
+            logger.error("No bom.xml could be located at: %s", commonConfig.getBomLocation());
             return false;
         }
 
-        Optional<UploadBomResponse> uploadBomResponse = doUpload(encodedBomOptional.get(), isLatest, projectTags);
+        Optional<UploadBomResponse> uploadBomResponse = doUpload(encodedBomOptional.get(),
+            commonConfig.isLatest(), commonConfig.getProjectTags());
 
         if (commonConfig.getPollingConfig().isEnabled() && uploadBomResponse.isPresent()) {
             try {
@@ -88,12 +88,10 @@ public class UploadBomAction {
     private Optional<UploadBomResponse> doUpload(String encodedBom, boolean isLatest, Set<String> projectTags) throws DependencyTrackException {
         try {
             Response<UploadBomResponse> response = bomClient.uploadBom(
-                new UploadBomRequest(commonConfig.getProjectName(),
-                                     commonConfig.getProjectVersion(),
-                                     true,
-                                     encodedBom,
-                                     isLatest,
-                                     projectTags));
+                new UploadBomRequest(commonConfig,
+                                     encodedBom
+                )
+            );
 
             if (response.isSuccess()) {
                 logger.info("BOM uploaded to Dependency Track server");

--- a/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojo.java
@@ -8,7 +8,6 @@ import io.github.pmckeown.dependencytrack.project.Project;
 import io.github.pmckeown.dependencytrack.project.ProjectAction;
 import io.github.pmckeown.dependencytrack.project.UpdateRequest;
 import io.github.pmckeown.util.Logger;
-import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;

--- a/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojo.java
@@ -51,7 +51,7 @@ public class UploadBomMojo extends AbstractDependencyTrackMojo {
     private boolean updateParent;
 
     @Parameter(defaultValue = "${project.parent.uuid}", property = "dependency-track.parentUuid")
-    private UUID parentUuid;
+    private String parentUuid;
 
     @Parameter(defaultValue = "${project.parent.name}", property = "dependency-track.parentName")
     private String parentName;
@@ -167,9 +167,9 @@ public class UploadBomMojo extends AbstractDependencyTrackMojo {
         this.updateParent = updateParent;
     }
 
-    public UUID getParentUuid() { return parentUuid; }
+    public String getParentUuid() { return parentUuid; }
 
-    public void setParentUuid(UUID parentUuid) { this.parentUuid = parentUuid; }
+    public void setParentUuid(String parentUuid) { this.parentUuid = parentUuid; }
 
     void setParentName(String parentName) {
         this.parentName = parentName;

--- a/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojo.java
@@ -78,10 +78,11 @@ public class UploadBomMojo extends AbstractDependencyTrackMojo {
 
     @Override
     public void performAction() throws MojoExecutionException, MojoFailureException {
+        enrichCommonConfig();
         logger.info("Update Project Parent : %s", updateParent);
 
         try {
-            if (!uploadBomAction.upload(getBomLocation(), isLatest, projectTags)) {
+            if (!uploadBomAction.upload()) {
                 handleFailure("Bom upload failed");
             }
             Project project = projectAction.getProject(projectName, projectVersion);
@@ -107,6 +108,16 @@ public class UploadBomMojo extends AbstractDependencyTrackMojo {
         }
     }
 
+    private void enrichCommonConfig() {
+        this.commonConfig.setBomLocation(getBomLocation());
+        this.commonConfig.setMavenProject(mavenProject);
+        this.commonConfig.setUpdateProjectInfo(updateProjectInfo);
+        this.commonConfig.setUpdateParent(updateParent);
+        this.commonConfig.setParentName(parentName);
+        this.commonConfig.setParentVersion(parentVersion);
+        this.commonConfig.setLatest(isLatest);
+        this.commonConfig.setProjectTags(projectTags);
+    }
     private Project getProjectParent(String parentName, String parentVersion)
             throws DependencyTrackException {
         if (StringUtils.isEmpty(parentName)) {

--- a/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojo.java
@@ -8,6 +8,7 @@ import io.github.pmckeown.dependencytrack.project.Project;
 import io.github.pmckeown.dependencytrack.project.ProjectAction;
 import io.github.pmckeown.dependencytrack.project.UpdateRequest;
 import io.github.pmckeown.util.Logger;
+import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -48,6 +49,9 @@ public class UploadBomMojo extends AbstractDependencyTrackMojo {
 
     @Parameter(property = "dependency-track.updateParent")
     private boolean updateParent;
+
+    @Parameter(defaultValue = "${project.parent.uuid}", property = "dependency-track.parentUuid")
+    private UUID parentUuid;
 
     @Parameter(defaultValue = "${project.parent.name}", property = "dependency-track.parentName")
     private String parentName;
@@ -113,6 +117,7 @@ public class UploadBomMojo extends AbstractDependencyTrackMojo {
         this.commonConfig.setMavenProject(mavenProject);
         this.commonConfig.setUpdateProjectInfo(updateProjectInfo);
         this.commonConfig.setUpdateParent(updateParent);
+        this.commonConfig.setParentUuid(parentUuid);
         this.commonConfig.setParentName(parentName);
         this.commonConfig.setParentVersion(parentVersion);
         this.commonConfig.setLatest(isLatest);
@@ -161,6 +166,10 @@ public class UploadBomMojo extends AbstractDependencyTrackMojo {
     void setUpdateParent(boolean updateParent) {
         this.updateParent = updateParent;
     }
+
+    public UUID getParentUuid() { return parentUuid; }
+
+    public void setParentUuid(UUID parentUuid) { this.parentUuid = parentUuid; }
 
     void setParentName(String parentName) {
         this.parentName = parentName;

--- a/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomRequest.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomRequest.java
@@ -2,7 +2,6 @@ package io.github.pmckeown.dependencytrack.upload;
 
 import io.github.pmckeown.dependencytrack.CommonConfig;
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 

--- a/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomRequest.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomRequest.java
@@ -3,6 +3,7 @@ package io.github.pmckeown.dependencytrack.upload;
 import io.github.pmckeown.dependencytrack.CommonConfig;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -17,14 +18,19 @@ import io.github.pmckeown.dependencytrack.project.ProjectTag;
  */
 public class UploadBomRequest {
 
+    private final UUID project;
     private final String projectName;
     private final String projectVersion;
     private final boolean autoCreate;
     private final String base64EncodedBom;
     private final boolean isLatest;
     private final List<ProjectTag> projectTags;
+    private final UUID parentUUID;
+    private final String parentName;
+    private final String parentVersion;
 
     UploadBomRequest(CommonConfig commonConfig, String base64EncodedBom) {
+        this.project = commonConfig.getProjectUuid();
         this.projectName = commonConfig.getProjectName();
         this.projectVersion = commonConfig.getProjectVersion();
         this.autoCreate = commonConfig.isAutoCreate();
@@ -35,6 +41,9 @@ public class UploadBomRequest {
         } else {
             this.projectTags = commonConfig.getProjectTags().stream().map(ProjectTag::new).collect(Collectors.toList());
         }
+        this.parentUUID = commonConfig.getParentUuid();
+        this.parentName = commonConfig.getParentName();
+        this.parentVersion = commonConfig.getParentVersion();
     }
 
     public String getProjectName() {
@@ -64,6 +73,18 @@ public class UploadBomRequest {
 
     public List<ProjectTag> getProjectTags() {
         return projectTags;
+    }
+
+    public UUID getParentUUID() {
+        return parentUUID;
+    }
+
+    public String getParentName() {
+        return parentName;
+    }
+
+    public String getParentVersion() {
+        return parentVersion;
     }
 
     @Override

--- a/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomRequest.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomRequest.java
@@ -2,7 +2,6 @@ package io.github.pmckeown.dependencytrack.upload;
 
 import io.github.pmckeown.dependencytrack.CommonConfig;
 import java.util.List;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;

--- a/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomRequest.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomRequest.java
@@ -17,19 +17,17 @@ import io.github.pmckeown.dependencytrack.project.ProjectTag;
  */
 public class UploadBomRequest {
 
-    private final UUID project;
     private final String projectName;
     private final String projectVersion;
     private final boolean autoCreate;
     private final String base64EncodedBom;
     private final boolean isLatest;
     private final List<ProjectTag> projectTags;
-    private final UUID parentUUID;
+    private final String parentUUID;
     private final String parentName;
     private final String parentVersion;
 
     UploadBomRequest(CommonConfig commonConfig, String base64EncodedBom) {
-        this.project = commonConfig.getProjectUuid();
         this.projectName = commonConfig.getProjectName();
         this.projectVersion = commonConfig.getProjectVersion();
         this.autoCreate = commonConfig.isAutoCreate();
@@ -74,7 +72,7 @@ public class UploadBomRequest {
         return projectTags;
     }
 
-    public UUID getParentUUID() {
+    public String getParentUUID() {
         return parentUUID;
     }
 

--- a/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomRequest.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomRequest.java
@@ -1,5 +1,6 @@
 package io.github.pmckeown.dependencytrack.upload;
 
+import io.github.pmckeown.dependencytrack.CommonConfig;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -23,16 +24,16 @@ public class UploadBomRequest {
     private final boolean isLatest;
     private final List<ProjectTag> projectTags;
 
-    UploadBomRequest(String projectName, String projectVersion, boolean autoCreate, String base64EncodedBom, boolean isLatest, Set<String> projectTags) {
-        this.projectName = projectName;
-        this.projectVersion = projectVersion;
-        this.autoCreate = autoCreate;
+    UploadBomRequest(CommonConfig commonConfig, String base64EncodedBom) {
+        this.projectName = commonConfig.getProjectName();
+        this.projectVersion = commonConfig.getProjectVersion();
+        this.autoCreate = commonConfig.isAutoCreate();
         this.base64EncodedBom = base64EncodedBom;
-        this.isLatest = isLatest;
-        if (projectTags == null) {
+        this.isLatest = commonConfig.isLatest();
+        if (commonConfig.getProjectTags() == null) {
             this.projectTags = null;
         } else {
-            this.projectTags = projectTags.stream().map(ProjectTag::new).collect(Collectors.toList());
+            this.projectTags = commonConfig.getProjectTags().stream().map(ProjectTag::new).collect(Collectors.toList());
         }
     }
 

--- a/src/test/java/io/github/pmckeown/dependencytrack/CommonConfigTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/CommonConfigTest.java
@@ -34,7 +34,7 @@ public class CommonConfigTest {
     }
 
     @Test
-    public void thatTheBomLocationIsDefaultedWhenNotSupplied() throws Exception {
+    public void thatTheBomLocationIsDefaultedWhenNotSupplied() {
         doReturn(new File(".")).when(project).getBasedir();
 
         assertThat(commonConfig.getBomLocation(), is(equalTo("./target/bom.xml")));

--- a/src/test/java/io/github/pmckeown/dependencytrack/CommonConfigTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/CommonConfigTest.java
@@ -1,0 +1,43 @@
+package io.github.pmckeown.dependencytrack;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.doReturn;
+
+import java.io.File;
+import org.apache.maven.project.MavenProject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CommonConfigTest {
+
+    private static final String PROJECT_NAME = "test";
+
+    private static final String PROJECT_VERSION = "1.0";
+
+    @Mock
+    private MavenProject project;
+
+    @InjectMocks
+    private CommonConfig commonConfig;
+
+    @Before
+    public void setup() {
+        commonConfig = new CommonConfig();
+        commonConfig.setMavenProject(project);
+    }
+
+    @Test
+    public void thatTheBomLocationIsDefaultedWhenNotSupplied() throws Exception {
+        doReturn(new File(".")).when(project).getBasedir();
+
+        assertThat(commonConfig.getBomLocation(), is(equalTo("./target/bom.xml")));
+        assertThat(commonConfig.isLatest(), is(equalTo(false)));
+    }
+}

--- a/src/test/java/io/github/pmckeown/dependencytrack/metrics/MetricsMojoIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/metrics/MetricsMojoIntegrationTest.java
@@ -3,7 +3,6 @@ package io.github.pmckeown.dependencytrack.metrics;
 import com.github.tomakehurst.wiremock.http.Fault;
 import io.github.pmckeown.dependencytrack.AbstractDependencyTrackMojoTest;
 import io.github.pmckeown.dependencytrack.PollingConfig;
-import io.github.pmckeown.dependencytrack.ResourceConstants;
 import io.github.pmckeown.dependencytrack.project.ProjectBuilder;
 
 import org.apache.maven.plugin.MojoExecutionException;

--- a/src/test/java/io/github/pmckeown/dependencytrack/upload/BomClientIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/upload/BomClientIntegrationTest.java
@@ -31,8 +31,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
-import java.util.Collections;
-
 public class BomClientIntegrationTest extends AbstractDependencyTrackIntegrationTest {
 
     private static final String BASE_64_ENCODED_BOM = "blah";

--- a/src/test/java/io/github/pmckeown/dependencytrack/upload/BomClientIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/upload/BomClientIntegrationTest.java
@@ -121,6 +121,6 @@ public class BomClientIntegrationTest extends AbstractDependencyTrackIntegration
      */
 
     private UploadBomRequest aBom() {
-        return new UploadBomRequest(PROJECT_NAME, PROJECT_VERSION, false, BASE_64_ENCODED_BOM, false, Collections.emptySet());
+        return new UploadBomRequest(getCommonConfig(), BASE_64_ENCODED_BOM);
     }
 }

--- a/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomActionTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomActionTest.java
@@ -131,7 +131,7 @@ public class UploadBomActionTest {
     }
 
     private Response aNotFoundResponse() {
-        return new Response(404, "Not Found", false);
+        return new Response(404, "Not Found", false, Optional.of("The parent component could not be found."));
     }
 
 }

--- a/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomActionTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomActionTest.java
@@ -3,7 +3,6 @@ package io.github.pmckeown.dependencytrack.upload;
 import io.github.pmckeown.dependencytrack.*;
 import io.github.pmckeown.util.BomEncoder;
 import io.github.pmckeown.util.Logger;
-import kong.unirest.UnirestException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -23,7 +22,6 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 

--- a/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoIntegrationTest.java
@@ -52,7 +52,7 @@ public class UploadBomMojoIntegrationTest extends AbstractDependencyTrackMojoTes
     }
 
     @Test
-    public void thatWhenFailOnErrorIsFalseAFailureFromToDependencyTrackDoesNotFailTheBuild() {
+    public void thatWhenFailOnErrorIsFalseAFailureFromToDependencyTrackDoesNotFailTheBuild() throws Exception {
         stubFor(put(urlEqualTo(ResourceConstants.V1_BOM)).willReturn(notFound()));
 
         try {
@@ -88,7 +88,7 @@ public class UploadBomMojoIntegrationTest extends AbstractDependencyTrackMojoTes
     }
 
     @Test
-    public void thatWhenFailOnErrorIsFalseAFailureToConnectToDependencyTrackDoesNotFailTheBuild() {
+    public void thatWhenFailOnErrorIsFalseAFailureToConnectToDependencyTrackDoesNotFailTheBuild() throws Exception {
         // No Wiremock Stubbing
 
         try {

--- a/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoTest.java
@@ -4,21 +4,16 @@ import io.github.pmckeown.dependencytrack.CommonConfig;
 import io.github.pmckeown.dependencytrack.metrics.MetricsAction;
 import io.github.pmckeown.dependencytrack.project.ProjectAction;
 import io.github.pmckeown.util.Logger;
-import java.lang.reflect.Field;
 import kong.unirest.Unirest;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import java.io.File;
 import java.util.Collections;
-import java.util.Set;
 
 import static io.github.pmckeown.dependencytrack.project.ProjectBuilder.aProject;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -60,26 +55,6 @@ public class UploadBomMojoTest {
     @Before
     public void setup() {
         uploadBomMojo.setMavenProject(project);
-    }
-
-    @Test
-    public void thatTheBomLocationIsDefaultedWhenNotSupplied() throws Exception {
-        doReturn(new File(".")).when(project).getBasedir();
-        doReturn(aProject().build()).when(projectAction).getProject(PROJECT_NAME, PROJECT_VERSION);
-        doReturn(true).when(uploadBomAction).upload();
-
-        uploadBomMojo.setProjectName(PROJECT_NAME);
-        uploadBomMojo.setProjectVersion(PROJECT_VERSION);
-        uploadBomMojo.setProjectTags(Collections.emptySet());
-        uploadBomMojo.execute();
-
-        verify(uploadBomAction).upload();
-
-        Field commonConfigField = uploadBomMojo.getClass().getDeclaredField("commonConfig");
-        commonConfigField.setAccessible(true);
-        CommonConfig commonConfig = (CommonConfig) commonConfigField.get(uploadBomMojo);
-        assertThat(commonConfig.getBomLocation(), is(equalTo("./target/bom.xml")));
-        assertThat(commonConfig.isLatest(), is(equalTo(false)));
     }
 
     @Test


### PR DESCRIPTION
feat: respect parentProject in upload request

When the upload request contains correct parent project information separate requests

  1. to check if the parent exists
  2. to move the uploaded project in the tree

will be skipped.
The big advantage is, that admin could separate permissions of teams using the new feature "Portfolio Access Control".

Additionally if the uploaded project already exists in any other version the user account does not need the permission PORTFOLIO_MANAGEMENT.