### PR TITLE
Consolidate upload (#432)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ The Automation team needs the following permissions:
 * In Dependency Track v4.4.x and later: 
   * BOM_UPLOAD
   * PORTFOLIO_MANAGEMENT
+  
+    Only when project should be automatically created. If a project exists in any version, this permission is not needed.
   * PROJECT_CREATION_UPLOAD
   * VIEW_PORTFOLIO
   * VIEW_VULNERABILITY
@@ -213,18 +215,20 @@ parent name will be defaulted to that POM's project parent name. If you wish to 
 no parent set within the `pom.xml`, then explicitly set `parentName` and `parentVersion`. `projectVersion` is optional 
 Dependency-Track, so this has no default to allow for blank values.
 
-**Note:** If the parent cannot be found on the Dependency-Track server, the BOM upload will not be attempted in order to
-prevent a project being incorrectly created or updated the server.
+**Note 1:** If both `parentUuid` and `parentName` / `parentVersion` are provided in configuration `parentUuid` will take precedence.
 
-| Property             | Required | Default Value          | Example Values            |
-|----------------------|----------|------------------------|---------------------------|
-| bomLocation          | false    | target/bom.xml         | target/custom-bom.xml     |
-| updateProjectInfo    | false    | false                  | false                     |
-| updateParent         | false    | false                  | true                      |
-| parentName           | false    | ${project.parent.name} | my-name-override          |
-| parentVersion        | false    |                        | ${project.parent.version} |
-| isLatest             | false    | false                  | true                      |
-| projectTags[].name   | false    | false                  | <name>tag1</name>         |
+**Note 2:** If a non-existing parent information is provided, the plugin will fail with `404 Not found`. 
+
+| Property           | Required | Default Value          | Example Values                        |
+|--------------------|----------|------------------------|---------------------------------------|
+| bomLocation        | false    | target/bom.xml         | target/custom-bom.xml                 |
+| updateProjectInfo  | false    | false                  | false                                 |
+| updateParent       | false    | false                  | true                                  |
+| parentUuid         | false    |                        | 628df5eb-a7fe-4c3f-831c-4536839a05ed  |
+| parentName         | false    | ${project.parent.name} | my-name-override                      |
+| parentVersion      | false    |                        | ${project.parent.version}             |
+| isLatest           | false    | false                  | true                                  |
+| projectTags[].name | false    | false                  | <name>tag1</name>                     |
 
 The `isLatest` option sets the flag on the project to indicate that it is the latest version.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,32 @@ in the `pluginManagement` section of your POM to avoid repetition.
     </plugins>
 </pluginManagement>
 ```
+Especially if you're in a multi-module configuration you should additionally include the plugin
+in the regular build plugin section that contains `<inherited>false</inherited>`.
+This assures that your submodules reflect the parent/child hierarchy of your pom.  
 
+```xml
+<plugins>
+      <!-- Generate SBOM file -->
+      <plugin>
+        <groupId>org.cyclonedx</groupId>
+        <artifactId>cyclonedx-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>io.github.pmckeown</groupId>
+        <artifactId>dependency-track-maven-plugin</artifactId>
+        <inherited>false</inherited>
+        <configuration>
+          <!-- set either -->
+          <parentUuid>UUID_OF_PARENT_PROJECT_IN_DTRACK</parentUuid>
+          <!-- or -->
+          <parentName>NAME_OF_PARENT_PROJECT_IN_DTRACK</parentName>
+          <parentVersion>VERSION_OF_PARENT_PROJECT_IN_DTRACK</parentVersion>
+        </configuration>
+      </plugin>
+  </plugins>
+  ```
+  
 **IMPORTANT** Dependency Track includes a front-end and an api-server component on different ports (defaulting to
 8080 and 8081 respectively). You must ensure that you target the api server component (8081) and not the front-end
 component URL in the `dependencyTrackBaseUrl` property.
@@ -208,6 +233,7 @@ Dependency-Track based on the metadata present in the BOM:
 
 **Notes:** 
 * This requires a CycloneDX BOM using Schema 1.2 or later.
+* required permission `PORTFOLIO_MANAGEMENT` if `updateProjectInfo` or `updateParent` is `true`
 * Not all information is visible in the Dependency-Track server UI.
 
 From Dependency-Track server 4.8.0 onwards, you can set the project parent by setting `updateParent` to `true`. The 

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.8.1</version>
+            <version>3.15.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -192,13 +192,13 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock</artifactId>
-            <version>2.27.2</version>
+            <version>3.0.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>4.9.0</version>
+            <version>5.14.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -208,7 +208,7 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.3.1</version>
+                    <version>3.4.0</version>
                 </plugin>
                 <!-- see http://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_maven-plugin_packaging -->
                 <plugin>
@@ -227,48 +227,48 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.9.0</version>
+                    <version>3.15.1</version>
                     <configuration>
                         <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                     </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.2.1</version>
+                    <version>3.5.2</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.4.2</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.1.3</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.1.3</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-invoker-plugin</artifactId>
-                    <version>3.6.0</version>
+                    <version>3.8.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.2.1</version>
+                    <version>3.3.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.4.1</version>
+                    <version>3.11.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.sonarsource.scanner.maven</groupId>
                     <artifactId>sonar-maven-plugin</artifactId>
-                    <version>3.9.1.2184</version>
+                    <version>5.0.0.4389</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.10</version>
+                    <version>0.8.12</version>
                     <configuration>
                         <append>true</append>
                     </configuration>

--- a/src/main/java/io/github/pmckeown/dependencytrack/AbstractDependencyTrackMojo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/AbstractDependencyTrackMojo.java
@@ -137,8 +137,8 @@ public abstract class AbstractDependencyTrackMojo extends AbstractMojo {
         this.skip = skip;
     }
 
-    public void setPollingConfig(PollingConfig commonConfig) {
-        this.pollingConfig = commonConfig;
+    public void setPollingConfig(PollingConfig pollingConfig) {
+        this.pollingConfig = pollingConfig;
     }
 
     protected void handleFailure(String message) throws MojoFailureException {

--- a/src/main/java/io/github/pmckeown/dependencytrack/AbstractDependencyTrackMojo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/AbstractDependencyTrackMojo.java
@@ -13,7 +13,6 @@ import org.apache.maven.plugins.annotations.Parameter;
 import static io.github.pmckeown.dependencytrack.ObjectMapperFactory.relaxedObjectMapper;
 import static kong.unirest.HeaderNames.ACCEPT;
 import static kong.unirest.HeaderNames.ACCEPT_ENCODING;
-
 /**
  * Base class for Mojos in this project.
  *

--- a/src/main/java/io/github/pmckeown/dependencytrack/CommonConfig.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/CommonConfig.java
@@ -1,6 +1,12 @@
 package io.github.pmckeown.dependencytrack;
 
+import io.github.pmckeown.util.Logger;
+import java.util.Collections;
+import java.util.Set;
 import javax.inject.Singleton;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.plugin.logging.SystemStreamLog;
+import org.apache.maven.project.MavenProject;
 
 /**
  * Holder for common configuration supplied on Mojo execution
@@ -15,10 +21,18 @@ public class CommonConfig {
     private String dependencyTrackBaseUrl;
     private String apiKey;
     private PollingConfig pollingConfig;
+    private String bomLocation;
+    private MavenProject mavenProject;
+    private boolean updateProjectInfo;
+    private boolean updateParent;
+    private String parentUuid;
+    private String parentName;
+    private String parentVersion;
+    private boolean isLatest;
+    private boolean autoCreate = true;
+    private Set<String> projectTags = Collections.emptySet();
 
-    public CommonConfig() {
-        // For dependency injection
-    }
+    protected Logger logger = new Logger(new SystemStreamLog());
 
     public String getProjectName() {
         return projectName;
@@ -59,5 +73,75 @@ public class CommonConfig {
     public void setPollingConfig(PollingConfig pollingConfig) {
         this.pollingConfig = pollingConfig;
     }
+    public Set<String> getProjectTags() {
+        return projectTags;
+    }
 
+    public void setProjectTags(Set<String> projectTags) {
+        this.projectTags = projectTags;
+    }
+
+    public boolean isLatest() {
+        return isLatest;
+    }
+
+    public void setLatest(boolean latest) {
+        isLatest = latest;
+    }
+
+    public String getParentVersion() {
+        return parentVersion;
+    }
+
+    public void setParentVersion(String parentVersion) {
+        this.parentVersion = parentVersion;
+    }
+
+
+    public String getParentUuid() { return parentUuid; }
+
+    public void setParentUuid(String parentUuid) { 
+        this.parentUuid = parentUuid; 
+    }
+
+    public String getParentName() {
+        return parentName;
+    }
+
+    public void setParentName(String parentName) {
+        this.parentName = parentName;
+    }
+
+    public boolean isUpdateParent() { return updateParent; }
+
+    public void setUpdateParent(boolean updateParent) {
+        this.updateParent = updateParent;
+    }
+
+    public boolean isUpdateProjectInfo() { return updateProjectInfo; }
+
+    public void setUpdateProjectInfo(boolean updateProjectInfo) { this.updateProjectInfo = updateProjectInfo; }
+
+    public MavenProject getMavenProject() { return mavenProject; }
+
+    public void setMavenProject(MavenProject mavenProject) {
+        this.mavenProject = mavenProject;
+    }
+
+    public void setBomLocation(String bomLocation) {
+        this.bomLocation = bomLocation;
+    }
+    public String getBomLocation() {
+        if (StringUtils.isNotBlank(bomLocation)) {
+            return bomLocation;
+        } else {
+            String defaultLocation = getMavenProject().getBasedir() + "/target/bom.xml";
+            this.logger.debug("bomLocation not supplied so using: %s", defaultLocation);
+            return defaultLocation;
+        }
+    }
+
+    public boolean isAutoCreate() {
+        return autoCreate;
+    }
 }

--- a/src/main/java/io/github/pmckeown/dependencytrack/CommonConfig.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/CommonConfig.java
@@ -16,8 +16,9 @@ import org.apache.maven.project.MavenProject;
 @Singleton
 public class CommonConfig {
 
-    private String projectName;
-    private String projectVersion;
+    private String projectUuid="";
+    private String projectName="";
+    private String projectVersion="";
     private String dependencyTrackBaseUrl;
     private String apiKey;
     private PollingConfig pollingConfig;
@@ -33,6 +34,10 @@ public class CommonConfig {
     private Set<String> projectTags = Collections.emptySet();
 
     protected Logger logger = new Logger(new SystemStreamLog());
+
+    public String getProjectUuid() { return projectUuid; }
+
+    public void setProjectUuid(String projectUuid) { this.projectUuid = projectUuid; }
 
     public String getProjectName() {
         return projectName;
@@ -94,14 +99,22 @@ public class CommonConfig {
     }
 
     public void setParentVersion(String parentVersion) {
-        this.parentVersion = parentVersion;
+        if (StringUtils.isBlank(parentUuid)) {
+            this.parentVersion = parentVersion;
+        } else if (StringUtils.isNotBlank(parentUuid))
+            logger.info("parentUuid set so ignoring parentVersion: %s", parentVersion);
     }
-
 
     public String getParentUuid() { return parentUuid; }
 
-    public void setParentUuid(String parentUuid) { 
-        this.parentUuid = parentUuid; 
+    public void setParentUuid(String parentUuid) {
+        this.parentUuid = parentUuid;
+        if (StringUtils.isNotBlank(parentUuid)) {
+            logger.info("parentUuid set to: %s", parentUuid);
+            logger.info("clearing parentName and parentVersion");
+            this.setParentName(null);
+            this.setParentVersion(null);
+        }
     }
 
     public String getParentName() {
@@ -109,16 +122,19 @@ public class CommonConfig {
     }
 
     public void setParentName(String parentName) {
-        this.parentName = parentName;
+        if (StringUtils.isBlank(parentUuid)) {
+            this.parentName = parentName;
+        } else if (StringUtils.isNotBlank(parentUuid))
+            logger.info("parentUuid set so ignoring parentName: %s", parentName);
     }
 
-    public boolean isUpdateParent() { return updateParent; }
+    public boolean getUpdateParent() { return updateParent; }
 
     public void setUpdateParent(boolean updateParent) {
         this.updateParent = updateParent;
     }
 
-    public boolean isUpdateProjectInfo() { return updateProjectInfo; }
+    public boolean getUpdateProjectInfo() { return updateProjectInfo; }
 
     public void setUpdateProjectInfo(boolean updateProjectInfo) { this.updateProjectInfo = updateProjectInfo; }
 

--- a/src/main/java/io/github/pmckeown/dependencytrack/finding/FindingsMojo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/finding/FindingsMojo.java
@@ -104,7 +104,7 @@ public class FindingsMojo extends AbstractDependencyTrackMojo {
     protected void performAction() throws MojoExecutionException, MojoFailureException {
         List<Finding> findings;
         try {
-            Project project = projectAction.getProject(commonConfig.getProjectName(), commonConfig.getProjectVersion());
+            Project project = projectAction.getProject(commonConfig);
             findings = findingsAction.getFindings(project);
             findingsPrinter.printFindings(project, findings);
             populateThresholdFromCliOptions();

--- a/src/main/java/io/github/pmckeown/dependencytrack/metrics/MetricsMojo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/metrics/MetricsMojo.java
@@ -75,7 +75,7 @@ public class MetricsMojo extends AbstractDependencyTrackMojo {
     @Override
     public void performAction() throws MojoExecutionException, MojoFailureException {
         try {
-            Project project = getProjectAction.getProject(projectName, projectVersion);
+            Project project = getProjectAction.getProject(commonConfig);
             logger.debug("Project Details: %s", project.toString());
 
             Metrics metrics = getMetrics(project);

--- a/src/main/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsMojo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsMojo.java
@@ -68,7 +68,7 @@ public class PolicyViolationsMojo extends AbstractDependencyTrackMojo {
     protected void performAction() throws MojoExecutionException, MojoFailureException {
         List<PolicyViolation> policyViolations;
         try {
-            Project project = projectAction.getProject(commonConfig.getProjectName(), commonConfig.getProjectVersion());
+            Project project = projectAction.getProject(commonConfig);
             policyViolations = policyAction.getPolicyViolations(project);
             policyViolationsPrinter.printPolicyViolations(project, policyViolations);
             boolean policyViolationsBreached = policyAnalyser.isAnyPolicyViolationBreached(policyViolations,

--- a/src/main/java/io/github/pmckeown/dependencytrack/project/DeleteProjectMojo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/project/DeleteProjectMojo.java
@@ -31,7 +31,7 @@ public class DeleteProjectMojo extends AbstractDependencyTrackMojo {
     @Override
     protected void performAction() throws MojoExecutionException, MojoFailureException {
         try {
-            Project project = projectAction.getProject(projectName, projectVersion);
+            Project project = projectAction.getProject(commonConfig);
 
             boolean success = projectAction.deleteProject(project);
 

--- a/src/main/java/io/github/pmckeown/dependencytrack/project/Project.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/project/Project.java
@@ -56,9 +56,4 @@ public class Project extends Item {
     public List<ProjectTag> getTags() {
         return tags;
     }
-
-    @Override
-    public String toString() {
-        return ToStringBuilder.reflectionToString(this, ToStringStyle.JSON_STYLE);
-    }
 }

--- a/src/main/java/io/github/pmckeown/dependencytrack/score/ScoreAction.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/score/ScoreAction.java
@@ -26,7 +26,7 @@ class ScoreAction {
 
     private ProjectClient projectClient;
     private MetricsAction metricsAction;
-    private CommonConfig commonConfig;
+    private CommonConfig commonConfig = new CommonConfig();
     private Logger logger;
 
     @Inject
@@ -40,7 +40,7 @@ class ScoreAction {
 
     Integer determineScore(Integer inheritedRiskScoreThreshold) throws DependencyTrackException {
         try {
-            Response<Project> response = projectClient.getProject(commonConfig.getProjectName(), commonConfig.getProjectVersion());
+            Response<Project> response = projectClient.getProject(commonConfig.getProjectUuid(), commonConfig.getProjectName(), commonConfig.getProjectVersion());
 
             Optional<Project> body = response.getBody();
             if (response.isSuccess() && body.isPresent()) {
@@ -88,5 +88,12 @@ class ScoreAction {
             logger.info(scoreMessage.toString());
         }
         logger.info(DELIMITER);
+    }
+
+    /*
+     * Setters for dependency injection in tests
+     */
+    void setCommonConfig(CommonConfig commonConfig) {
+        this.commonConfig = commonConfig;
     }
 }

--- a/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojo.java
@@ -49,6 +49,9 @@ public class UploadBomMojo extends AbstractDependencyTrackMojo {
     @Parameter(property = "dependency-track.updateParent")
     private boolean updateParent;
 
+    @Parameter(defaultValue = "${project.parent.uuid}", property = "dependency-track.parentUuid")
+    private String parentUuid;
+
     @Parameter(defaultValue = "${project.parent.name}", property = "dependency-track.parentName")
     private String parentName;
 
@@ -78,10 +81,11 @@ public class UploadBomMojo extends AbstractDependencyTrackMojo {
 
     @Override
     public void performAction() throws MojoExecutionException, MojoFailureException {
+        enrichCommonConfig();
         logger.info("Update Project Parent : %s", updateParent);
 
         try {
-            if (!uploadBomAction.upload(getBomLocation(), isLatest, projectTags)) {
+            if (!uploadBomAction.upload()) {
                 handleFailure("Bom upload failed");
             }
             Project project = projectAction.getProject(projectName, projectVersion);
@@ -107,6 +111,17 @@ public class UploadBomMojo extends AbstractDependencyTrackMojo {
         }
     }
 
+    private void enrichCommonConfig() {
+        this.commonConfig.setBomLocation(getBomLocation());
+        this.commonConfig.setMavenProject(mavenProject);
+        this.commonConfig.setUpdateProjectInfo(updateProjectInfo);
+        this.commonConfig.setUpdateParent(updateParent);
+        this.commonConfig.setParentUuid(parentUuid);
+        this.commonConfig.setParentName(parentName);
+        this.commonConfig.setParentVersion(parentVersion);
+        this.commonConfig.setLatest(isLatest);
+        this.commonConfig.setProjectTags(projectTags);
+    }
     private Project getProjectParent(String parentName, String parentVersion)
             throws DependencyTrackException {
         if (StringUtils.isEmpty(parentName)) {
@@ -150,6 +165,10 @@ public class UploadBomMojo extends AbstractDependencyTrackMojo {
     void setUpdateParent(boolean updateParent) {
         this.updateParent = updateParent;
     }
+
+    public String getParentUuid() { return parentUuid; }
+
+    public void setParentUuid(String parentUuid) { this.parentUuid = parentUuid; }
 
     void setParentName(String parentName) {
         this.parentName = parentName;

--- a/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojo.java
@@ -135,7 +135,7 @@ public class UploadBomMojo extends AbstractDependencyTrackMojo {
     }
 
     private Project getProjectParentByUuid(String uuid) throws DependencyTrackException {
-        logger.info("Attempting to fetch project parent: '%s'", parentUuid);
+        logger.info("Attempting to fetch project parent: '%s'", uuid);
         try {
             return projectAction.getProject(uuid);
         } catch (DependencyTrackException ex) {
@@ -147,13 +147,13 @@ public class UploadBomMojo extends AbstractDependencyTrackMojo {
     }
 
     private Project getProjectParentByNameAndVersion(String name, String version) throws DependencyTrackException {
-        logger.info("Attempting to fetch project parent: '%s-%s'", parentName, parentVersion);
+        logger.info("Attempting to fetch project parent: '%s-%s'", name, version);
         try {
-            return projectAction.getProject(commonConfig.getParentName(), commonConfig.getParentVersion());
+            return projectAction.getProject(name, version);
         } catch (DependencyTrackException ex) {
             logger.error("Failed to find parent project with name ['%s-%s']. Check the update parent " +
                 "your settings for this plugin and verify if a matching parent project exists in the " +
-                "server.", parentName, parentVersion);
+                "server.", name, version);
             throw ex;
         }
     }

--- a/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomRequest.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomRequest.java
@@ -1,7 +1,7 @@
 package io.github.pmckeown.dependencytrack.upload;
 
+import io.github.pmckeown.dependencytrack.CommonConfig;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -22,18 +22,24 @@ public class UploadBomRequest {
     private final String base64EncodedBom;
     private final boolean isLatest;
     private final List<ProjectTag> projectTags;
+    private final String parentUUID;
+    private final String parentName;
+    private final String parentVersion;
 
-    UploadBomRequest(String projectName, String projectVersion, boolean autoCreate, String base64EncodedBom, boolean isLatest, Set<String> projectTags) {
-        this.projectName = projectName;
-        this.projectVersion = projectVersion;
-        this.autoCreate = autoCreate;
+    UploadBomRequest(CommonConfig commonConfig, String base64EncodedBom) {
+        this.projectName = commonConfig.getProjectName();
+        this.projectVersion = commonConfig.getProjectVersion();
+        this.autoCreate = commonConfig.isAutoCreate();
         this.base64EncodedBom = base64EncodedBom;
-        this.isLatest = isLatest;
-        if (projectTags == null) {
+        this.isLatest = commonConfig.isLatest();
+        if (commonConfig.getProjectTags() == null) {
             this.projectTags = null;
         } else {
-            this.projectTags = projectTags.stream().map(ProjectTag::new).collect(Collectors.toList());
+            this.projectTags = commonConfig.getProjectTags().stream().map(ProjectTag::new).collect(Collectors.toList());
         }
+        this.parentUUID = commonConfig.getParentUuid();
+        this.parentName = commonConfig.getParentName();
+        this.parentVersion = commonConfig.getParentVersion();
     }
 
     public String getProjectName() {
@@ -63,6 +69,18 @@ public class UploadBomRequest {
 
     public List<ProjectTag> getProjectTags() {
         return projectTags;
+    }
+
+    public String getParentUUID() {
+        return parentUUID;
+    }
+
+    public String getParentName() {
+        return parentName;
+    }
+
+    public String getParentVersion() {
+        return parentVersion;
     }
 
     @Override

--- a/src/test/java/io/github/pmckeown/dependencytrack/CommonConfigTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/CommonConfigTest.java
@@ -1,0 +1,43 @@
+package io.github.pmckeown.dependencytrack;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.doReturn;
+
+import java.io.File;
+import org.apache.maven.project.MavenProject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CommonConfigTest {
+
+    private static final String PROJECT_NAME = "test";
+
+    private static final String PROJECT_VERSION = "1.0";
+
+    @Mock
+    private MavenProject project;
+
+    @InjectMocks
+    private CommonConfig commonConfig;
+
+    @Before
+    public void setup() {
+        commonConfig = new CommonConfig();
+        commonConfig.setMavenProject(project);
+    }
+
+    @Test
+    public void thatTheBomLocationIsDefaultedWhenNotSupplied() {
+        doReturn(new File(".")).when(project).getBasedir();
+
+        assertThat(commonConfig.getBomLocation(), is(equalTo("./target/bom.xml")));
+        assertThat(commonConfig.isLatest(), is(equalTo(false)));
+    }
+}

--- a/src/test/java/io/github/pmckeown/dependencytrack/metrics/MetricsMojoIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/metrics/MetricsMojoIntegrationTest.java
@@ -3,7 +3,6 @@ package io.github.pmckeown.dependencytrack.metrics;
 import com.github.tomakehurst.wiremock.http.Fault;
 import io.github.pmckeown.dependencytrack.AbstractDependencyTrackMojoTest;
 import io.github.pmckeown.dependencytrack.PollingConfig;
-import io.github.pmckeown.dependencytrack.ResourceConstants;
 import io.github.pmckeown.dependencytrack.project.ProjectBuilder;
 
 import org.apache.maven.plugin.MojoExecutionException;

--- a/src/test/java/io/github/pmckeown/dependencytrack/project/ProjectActionTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/project/ProjectActionTest.java
@@ -38,9 +38,6 @@ import static org.mockito.Mockito.doThrow;
 @RunWith(MockitoJUnitRunner.class)
 public class ProjectActionTest {
 
-    private static final String UUID_1 = "project-uuid-1";
-    private static final String PROJECT_NAME_1 = "projectName1";
-    private static final String PROJECT_VERSION_1 = "projectVersion1";
     private static final String UUID_2 = "project-uuid-2";
     private static final String PROJECT_NAME_2 = "projectName2";
     private static final String PROJECT_VERSION_2 = "projectVersion2";
@@ -261,12 +258,6 @@ public class ProjectActionTest {
         CommonConfig commonConfig = new CommonConfig();
         commonConfig.setProjectName(PROJECT_NAME_2);
         commonConfig.setProjectVersion(PROJECT_VERSION_2);
-        return commonConfig;
-    }
-
-    private CommonConfig commonConfig2() {
-        CommonConfig commonConfig = new CommonConfig();
-        commonConfig.setProjectUuid(UUID_2);
         return commonConfig;
     }
 }

--- a/src/test/java/io/github/pmckeown/dependencytrack/upload/BomClientIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/upload/BomClientIntegrationTest.java
@@ -31,8 +31,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
-import java.util.Collections;
-
 public class BomClientIntegrationTest extends AbstractDependencyTrackIntegrationTest {
 
     private static final String BASE_64_ENCODED_BOM = "blah";
@@ -121,6 +119,6 @@ public class BomClientIntegrationTest extends AbstractDependencyTrackIntegration
      */
 
     private UploadBomRequest aBom() {
-        return new UploadBomRequest(PROJECT_NAME, PROJECT_VERSION, false, BASE_64_ENCODED_BOM, false, Collections.emptySet());
+        return new UploadBomRequest(getCommonConfig(), BASE_64_ENCODED_BOM);
     }
 }

--- a/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoIntegrationTest.java
@@ -52,7 +52,7 @@ public class UploadBomMojoIntegrationTest extends AbstractDependencyTrackMojoTes
     }
 
     @Test
-    public void thatWhenFailOnErrorIsFalseAFailureFromToDependencyTrackDoesNotFailTheBuild() {
+    public void thatWhenFailOnErrorIsFalseAFailureFromToDependencyTrackDoesNotFailTheBuild() throws Exception {
         stubFor(put(urlEqualTo(ResourceConstants.V1_BOM)).willReturn(notFound()));
 
         try {
@@ -88,7 +88,7 @@ public class UploadBomMojoIntegrationTest extends AbstractDependencyTrackMojoTes
     }
 
     @Test
-    public void thatWhenFailOnErrorIsFalseAFailureToConnectToDependencyTrackDoesNotFailTheBuild() {
+    public void thatWhenFailOnErrorIsFalseAFailureToConnectToDependencyTrackDoesNotFailTheBuild() throws Exception {
         // No Wiremock Stubbing
 
         try {

--- a/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoIntegrationTest.java
@@ -226,34 +226,6 @@ public class UploadBomMojoIntegrationTest extends AbstractDependencyTrackMojoTes
     }
 
     @Test
-    public void thatProjectParentNameAndVersionCanBeProvided() throws Exception {
-        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP))
-            .withQueryParam("name", equalTo("test-parent"))
-            .willReturn(aResponse().withBodyFile("api/v1/project/test-parent.json")));
-        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP)).atPriority(1)
-            .withQueryParam("name", equalTo("test-project"))
-            .willReturn(aResponse().withBodyFile("api/v1/project/test-project.json")));
-        stubFor(get(urlPathMatching(TestResourceConstants.V1_PROJECT_UUID)).willReturn(ok()));
-        stubFor(patch(urlPathMatching(TestResourceConstants.V1_PROJECT_UUID)).willReturn(ok()));
-        stubFor(get(urlPathMatching(TestResourceConstants.V1_BOM_TOKEN_UUID)).willReturn(ok()));
-        stubFor(put(urlEqualTo(V1_BOM)).willReturn(
-                aResponse().withBodyFile("api/v1/project/upload-bom-response.json")));
-        stubFor(get(urlPathMatching(TestResourceConstants.V1_METRICS_PROJECT_REFRESH)).willReturn(ok()));
-
-        UploadBomMojo uploadBomMojo = uploadBomMojo(BOM_LOCATION);
-        uploadBomMojo.setProjectName("test-project");
-        uploadBomMojo.setUpdateParent(true);
-        uploadBomMojo.setParentName("test-parent");
-        uploadBomMojo.setParentVersion("1.0.0-SNAPSHOT");
-        uploadBomMojo.setFailOnError(true);
-        uploadBomMojo.execute();
-
-        verify(exactly(1), patchRequestedFor(urlPathMatching(TestResourceConstants.V1_PROJECT_UUID))
-                .withRequestBody(
-                        matchingJsonPath("$.parent.uuid", equalTo("8977c66f-b310-aced-face-e63e9eb7c4cf"))));
-    }
-
-    @Test
     public void thatProjectParentNameAndVersionCanBeIgnored() throws Exception {
         stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP))
             .willReturn(aResponse().withBodyFile("api/v1/project/test-project.json")));

--- a/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoTest.java
@@ -10,23 +10,16 @@ import org.apache.maven.project.MavenProject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import java.io.File;
 import java.util.Collections;
-import java.util.Set;
 
 import static io.github.pmckeown.dependencytrack.project.ProjectBuilder.aProject;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anySet;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -62,25 +55,6 @@ public class UploadBomMojoTest {
     @Before
     public void setup() {
         uploadBomMojo.setMavenProject(project);
-    }
-
-    @Test
-    public void thatTheBomLocationIsDefaultedWhenNotSupplied() throws Exception {
-        ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<Boolean> argumentCaptor2 = ArgumentCaptor.forClass(Boolean.class);
-        ArgumentCaptor<Set<String>> argumentCaptor3 = ArgumentCaptor.forClass(Set.class);
-        doReturn(new File(".")).when(project).getBasedir();
-        doReturn(aProject().build()).when(projectAction).getProject(PROJECT_NAME, PROJECT_VERSION);
-        doReturn(true).when(uploadBomAction).upload(anyString(), anyBoolean(), anySet());
-
-        uploadBomMojo.setProjectName(PROJECT_NAME);
-        uploadBomMojo.setProjectVersion(PROJECT_VERSION);
-        uploadBomMojo.setProjectTags(Collections.emptySet());
-        uploadBomMojo.execute();
-
-        verify(uploadBomAction).upload(argumentCaptor.capture(), argumentCaptor2.capture(), argumentCaptor3.capture());
-        assertThat(argumentCaptor.getValue(), is(equalTo("./target/bom.xml")));
-        assertThat(argumentCaptor2.getValue(), is(equalTo(false)));
     }
 
     @Test
@@ -145,7 +119,7 @@ public class UploadBomMojoTest {
 
     @Test
     public void thatWhenUpdateParentFailsTheLoggerIsCalledAndBuildFails() throws Exception {
-        doReturn(true).when(uploadBomAction).upload(anyString(), anyBoolean(), anySet());
+        doReturn(true).when(uploadBomAction).upload();
         doReturn(aProject().withName("project-parent").withVersion("1.2.3").build())
                 .when(projectAction).getProject("project-parent", "1.2.3");
 
@@ -166,7 +140,7 @@ public class UploadBomMojoTest {
 
     @Test
     public void thatUpdateParentFailsWhenParentNameIsNull() throws Exception {
-        doReturn(true).when(uploadBomAction).upload(anyString(), anyBoolean(), anySet());
+        doReturn(true).when(uploadBomAction).upload();
 
         uploadBomMojo.setParentName(null);
         uploadBomMojo.setParentVersion(null);

--- a/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoTest.java
@@ -15,7 +15,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import java.util.Collections;
 
-import static io.github.pmckeown.dependencytrack.project.ProjectBuilder.aProject;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -54,6 +53,7 @@ public class UploadBomMojoTest {
 
     @Before
     public void setup() {
+        uploadBomMojo.setCommonConfig(commonConfig);
         uploadBomMojo.setMavenProject(project);
     }
 
@@ -120,9 +120,13 @@ public class UploadBomMojoTest {
     @Test
     public void thatWhenUpdateParentFailsTheLoggerIsCalledAndBuildFails() throws Exception {
         doReturn(true).when(uploadBomAction).upload();
-        doReturn(aProject().withName("project-parent").withVersion("1.2.3").build())
-                .when(projectAction).getProject("project-parent", "1.2.3");
 
+        CommonConfig config = new CommonConfig();
+        config.setProjectName("project-parent");
+        config.setProjectVersion("1.2.3");
+        config.setUpdateParent(true);
+
+        uploadBomMojo.setCommonConfig(config);
         uploadBomMojo.setParentName("project-parent");
         uploadBomMojo.setParentVersion("1.2.3");
         uploadBomMojo.setUpdateParent(true);

--- a/src/test/resources/__files/api/v1/project/test-parent.json
+++ b/src/test/resources/__files/api/v1/project/test-parent.json
@@ -1,4 +1,3 @@
-
 {
   "name": "test-parent",
   "version": "1.0.0-SNAPSHOT",


### PR DESCRIPTION
* feat: merge uploadConfig into CommonConfig

* chore: tests successful changes compiled

* feat: respect parentProject in upload request

When the upload request contains correct parent project information separate requests

  1. to check if the parent exists
  2. to move the uploaded project in the tree

could be skipped.
The big advantage is, that admin could separate permissions of teams using the new feature "Portfolio Access Control".

Additionally if the uploaded project already exists in any other version the user account does not need the permission PORTFOLIO_MANAGEMENT.

* chore: housekeeping

* chore: fixed README.md

* chore: fixed SonarQube findings

* chore: fixed SonarQube findings

* fix: added parentUuid to put request

* fix: updated README.md

* fix: replaced UUID type with String

* fix: README.md

* chore: Removed unused import 'java.util.UUID'.

* Update src/main/java/io/github/pmckeown/dependencytrack/CommonConfig.java



* chore: implemented review comments

---------