### PR TITLE
Make module parameters thread-safe

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,9 +192,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
+            <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
-            <version>3.0.1</version>
+            <version>3.0.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/io/github/pmckeown/dependencytrack/AbstractDependencyTrackMojo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/AbstractDependencyTrackMojo.java
@@ -13,9 +13,10 @@ import org.apache.maven.plugins.annotations.Parameter;
 import static io.github.pmckeown.dependencytrack.ObjectMapperFactory.relaxedObjectMapper;
 import static kong.unirest.HeaderNames.ACCEPT;
 import static kong.unirest.HeaderNames.ACCEPT_ENCODING;
+
 /**
  * Base class for Mojos in this project.
- *
+ * <p>
  * Provides common configuration options:
  * <ol>
  *     <li>projectName</li>
@@ -69,26 +70,29 @@ public abstract class AbstractDependencyTrackMojo extends AbstractMojo {
 
     protected CommonConfig commonConfig;
 
-    protected AbstractDependencyTrackMojo(CommonConfig commonConfig, Logger logger) {
+    protected ModuleConfig moduleConfig;
+
+    protected AbstractDependencyTrackMojo(CommonConfig commonConfig, ModuleConfig moduleConfig, Logger logger) {
         this.logger = logger;
         this.commonConfig = commonConfig;
+        this.moduleConfig = moduleConfig;
     }
 
     /**
      * Initialises the {@link Logger} and {@link CommonConfig} instances that were injected by the SISU inversion of
      * control container (using Guice under the hood) by providing the data provided by the Plexus IOC container.
-     *
+     * <p>
      * Then performs the action defined by the subclass.
      */
     @Override
     public final void execute() throws MojoExecutionException, MojoFailureException {
         // Set up Mojo environment
         this.logger.setLog(getLog());
-        this.commonConfig.setProjectName(projectName);
-        this.commonConfig.setProjectVersion(projectVersion);
         this.commonConfig.setDependencyTrackBaseUrl(dependencyTrackBaseUrl);
         this.commonConfig.setApiKey(apiKey);
         this.commonConfig.setPollingConfig(this.pollingConfig != null ? this.pollingConfig : PollingConfig.defaults());
+        this.moduleConfig.setProjectName(projectName);
+        this.moduleConfig.setProjectVersion(projectVersion);
 
         // Configure Unirest with additional user-supplied configuration
         configureUnirest();
@@ -105,7 +109,7 @@ public abstract class AbstractDependencyTrackMojo extends AbstractMojo {
      * Template method to be implemented by subclasses.
      *
      * @throws MojoExecutionException when an error is encountered during Mojo execution
-     * @throws MojoFailureException when the Mojo fails
+     * @throws MojoFailureException   when the Mojo fails
      */
     protected abstract void performAction() throws MojoExecutionException, MojoFailureException;
 
@@ -132,7 +136,7 @@ public abstract class AbstractDependencyTrackMojo extends AbstractMojo {
     public void setVerifySsl(boolean verifySsl) {
         this.verifySsl = verifySsl;
     }
-    
+
     public void setSkip(String skip) {
         this.skip = skip;
     }
@@ -157,8 +161,8 @@ public abstract class AbstractDependencyTrackMojo extends AbstractMojo {
 
     private boolean getSkip() {
         return Boolean.parseBoolean(skip)
-                 || ("releases".equals(skip) && !ArtifactUtils.isSnapshot(projectVersion))
-                 || ("snapshots".equals(skip) && ArtifactUtils.isSnapshot(projectVersion));
+                || ("releases".equals(skip) && !ArtifactUtils.isSnapshot(projectVersion))
+                || ("snapshots".equals(skip) && ArtifactUtils.isSnapshot(projectVersion));
     }
 
     /**

--- a/src/main/java/io/github/pmckeown/dependencytrack/CommonConfig.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/CommonConfig.java
@@ -1,12 +1,6 @@
 package io.github.pmckeown.dependencytrack;
 
-import io.github.pmckeown.util.Logger;
-import java.util.Collections;
-import java.util.Set;
 import javax.inject.Singleton;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.maven.plugin.logging.SystemStreamLog;
-import org.apache.maven.project.MavenProject;
 
 /**
  * Holder for common configuration supplied on Mojo execution
@@ -16,148 +10,32 @@ import org.apache.maven.project.MavenProject;
 @Singleton
 public class CommonConfig {
 
-    private String projectUuid="";
-    private String projectName="";
-    private String projectVersion="";
     private String dependencyTrackBaseUrl;
     private String apiKey;
     private PollingConfig pollingConfig;
-    private String bomLocation;
-    private MavenProject mavenProject;
-    private boolean updateProjectInfo;
-    private boolean updateParent;
-    private String parentUuid;
-    private String parentName;
-    private String parentVersion;
-    private boolean isLatest;
-    private boolean autoCreate = true;
-    private Set<String> projectTags = Collections.emptySet();
-
-    protected Logger logger = new Logger(new SystemStreamLog());
-
-    public String getProjectUuid() { return projectUuid; }
-
-    public void setProjectUuid(String projectUuid) { this.projectUuid = projectUuid; }
-
-    public String getProjectName() {
-        return projectName;
-    }
-
-    public String getProjectVersion() {
-        return projectVersion;
-    }
 
     public String getDependencyTrackBaseUrl() {
         return dependencyTrackBaseUrl;
-    }
-
-    public String getApiKey() {
-        return apiKey;
-    }
-
-    public PollingConfig getPollingConfig() {
-        return pollingConfig;
-    }
-
-    public void setProjectName(String projectName) {
-        this.projectName = projectName;
-    }
-
-    public void setProjectVersion(String projectVersion) {
-        this.projectVersion = projectVersion;
     }
 
     public void setDependencyTrackBaseUrl(String dependencyTrackBaseUrl) {
         this.dependencyTrackBaseUrl = dependencyTrackBaseUrl;
     }
 
+    public String getApiKey() {
+        return apiKey;
+    }
+
     public void setApiKey(String apiKey) {
         this.apiKey = apiKey;
+    }
+
+    public PollingConfig getPollingConfig() {
+        return pollingConfig;
     }
 
     public void setPollingConfig(PollingConfig pollingConfig) {
         this.pollingConfig = pollingConfig;
     }
-    public Set<String> getProjectTags() {
-        return projectTags;
-    }
 
-    public void setProjectTags(Set<String> projectTags) {
-        this.projectTags = projectTags;
-    }
-
-    public boolean isLatest() {
-        return isLatest;
-    }
-
-    public void setLatest(boolean latest) {
-        isLatest = latest;
-    }
-
-    public String getParentVersion() {
-        return parentVersion;
-    }
-
-    public void setParentVersion(String parentVersion) {
-        if (StringUtils.isBlank(parentUuid)) {
-            this.parentVersion = parentVersion;
-        } else if (StringUtils.isNotBlank(parentUuid))
-            logger.info("parentUuid set so ignoring parentVersion: %s", parentVersion);
-    }
-
-    public String getParentUuid() { return parentUuid; }
-
-    public void setParentUuid(String parentUuid) {
-        this.parentUuid = parentUuid;
-        if (StringUtils.isNotBlank(parentUuid)) {
-            logger.info("parentUuid set to: %s", parentUuid);
-            logger.info("clearing parentName and parentVersion");
-            this.setParentName(null);
-            this.setParentVersion(null);
-        }
-    }
-
-    public String getParentName() {
-        return parentName;
-    }
-
-    public void setParentName(String parentName) {
-        if (StringUtils.isBlank(parentUuid)) {
-            this.parentName = parentName;
-        } else if (StringUtils.isNotBlank(parentUuid))
-            logger.info("parentUuid set so ignoring parentName: %s", parentName);
-    }
-
-    public boolean getUpdateParent() { return updateParent; }
-
-    public void setUpdateParent(boolean updateParent) {
-        this.updateParent = updateParent;
-    }
-
-    public boolean getUpdateProjectInfo() { return updateProjectInfo; }
-
-    public void setUpdateProjectInfo(boolean updateProjectInfo) { this.updateProjectInfo = updateProjectInfo; }
-
-    public MavenProject getMavenProject() { return mavenProject; }
-
-    public void setMavenProject(MavenProject mavenProject) {
-        this.mavenProject = mavenProject;
-    }
-
-    public void setBomLocation(String bomLocation) {
-        this.bomLocation = bomLocation;
-    }
-    public String getBomLocation() {
-        if (StringUtils.isNotBlank(bomLocation)) {
-            return bomLocation;
-        } else {
-            String defaultLocation = getMavenProject().getBasedir() + "/target/bom.xml";
-            this.logger.debug("bomLocation not supplied so using: %s", defaultLocation);
-            return defaultLocation;
-        }
-    }
-
-    public boolean isAutoCreate() {
-        return autoCreate;
-    }
 }

--- a/src/main/java/io/github/pmckeown/dependencytrack/ModuleConfig.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/ModuleConfig.java
@@ -1,0 +1,151 @@
+package io.github.pmckeown.dependencytrack;
+
+import io.github.pmckeown.util.Logger;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.plugin.logging.SystemStreamLog;
+import org.apache.maven.project.MavenProject;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Holder for module dependent configuration supplied on Mojo execution
+ *
+ */
+public class ModuleConfig {
+
+    private String projectUuid = "";
+    private String projectName = "";
+    private String projectVersion = "";
+    private String bomLocation;
+    private String parentUuid;
+    private String parentName;
+    private String parentVersion;
+    private MavenProject mavenProject;
+    private boolean updateProjectInfo;
+    private boolean updateParent;
+    private boolean isLatest;
+    private boolean autoCreate = true;
+    private Set<String> projectTags = Collections.emptySet();
+
+    protected Logger logger = new Logger(new SystemStreamLog());
+
+    public String getProjectUuid() {
+        return projectUuid;
+    }
+
+    public void setProjectUuid(String projectUuid) {
+        this.projectUuid = projectUuid;
+    }
+
+    public String getProjectName() {
+        return projectName;
+    }
+
+    public void setProjectName(String projectName) {
+        this.projectName = projectName;
+    }
+
+    public String getProjectVersion() {
+        return projectVersion;
+    }
+
+    public void setProjectVersion(String projectVersion) {
+        this.projectVersion = projectVersion;
+    }
+
+    public String getBomLocation() {
+        if (StringUtils.isNotBlank(bomLocation)) {
+            return bomLocation;
+        } else {
+            String defaultLocation = getMavenProject().getBasedir() + "/target/bom.xml";
+            this.logger.debug("bomLocation not supplied so using: %s", defaultLocation);
+            return defaultLocation;
+        }
+    }
+
+    public void setBomLocation(String bomLocation) {
+        this.bomLocation = bomLocation;
+    }
+
+    public String getParentUuid() {
+        return parentUuid;
+    }
+
+    public void setParentUuid(String parentUuid) {
+        this.parentUuid = parentUuid;
+        if (StringUtils.isNotBlank(parentUuid)) {
+            logger.info("parentUuid set to: %s", parentUuid);
+            logger.info("clearing parentName and parentVersion");
+            this.setParentName(null);
+            this.setParentVersion(null);
+        }
+    }
+
+    public String getParentName() {
+        return parentName;
+    }
+
+    public void setParentName(String parentName) {
+        if (StringUtils.isBlank(parentUuid)) {
+            this.parentName = parentName;
+        } else if (StringUtils.isNotBlank(parentUuid))
+            logger.info("parentUuid set so ignoring parentName: %s", parentName);
+    }
+
+    public String getParentVersion() {
+        return parentVersion;
+    }
+
+    public void setParentVersion(String parentVersion) {
+        if (StringUtils.isBlank(parentUuid)) {
+            this.parentVersion = parentVersion;
+        } else if (StringUtils.isNotBlank(parentUuid))
+            logger.info("parentUuid set so ignoring parentVersion: %s", parentVersion);
+    }
+
+    public MavenProject getMavenProject() {
+        return mavenProject;
+    }
+
+    public void setMavenProject(MavenProject mavenProject) {
+        this.mavenProject = mavenProject;
+    }
+
+    public boolean getUpdateParent() {
+        return updateParent;
+    }
+
+    public void setUpdateParent(boolean updateParent) {
+        this.updateParent = updateParent;
+    }
+
+    public boolean getUpdateProjectInfo() {
+        return updateProjectInfo;
+    }
+
+    public void setUpdateProjectInfo(boolean updateProjectInfo) {
+        this.updateProjectInfo = updateProjectInfo;
+    }
+
+    public boolean isLatest() {
+        return isLatest;
+    }
+
+    public void setLatest(boolean latest) {
+        isLatest = latest;
+    }
+
+    public boolean isAutoCreate() {
+        return autoCreate;
+    }
+
+    public Set<String> getProjectTags() {
+        return projectTags;
+    }
+
+    public void setProjectTags(Set<String> projectTags) {
+        this.projectTags = projectTags;
+    }
+
+}

--- a/src/main/java/io/github/pmckeown/dependencytrack/finding/FindingsMojo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/finding/FindingsMojo.java
@@ -3,6 +3,7 @@ package io.github.pmckeown.dependencytrack.finding;
 import io.github.pmckeown.dependencytrack.AbstractDependencyTrackMojo;
 import io.github.pmckeown.dependencytrack.CommonConfig;
 import io.github.pmckeown.dependencytrack.DependencyTrackException;
+import io.github.pmckeown.dependencytrack.ModuleConfig;
 import io.github.pmckeown.dependencytrack.finding.report.FindingsReportGenerator;
 import io.github.pmckeown.dependencytrack.project.Project;
 import io.github.pmckeown.dependencytrack.project.ProjectAction;
@@ -91,8 +92,8 @@ public class FindingsMojo extends AbstractDependencyTrackMojo {
     @Inject
     public FindingsMojo(ProjectAction projectAction, FindingsAction findingsAction, FindingsPrinter findingsPrinter,
                         FindingsAnalyser findingsAnalyser, FindingsReportGenerator findingsReportGenerator,
-                        CommonConfig commonConfig, Logger logger) {
-        super(commonConfig, logger);
+                        CommonConfig commonConfig, ModuleConfig moduleConfig, Logger logger) {
+        super(commonConfig, moduleConfig, logger);
         this.projectAction = projectAction;
         this.findingsAction = findingsAction;
         this.findingsPrinter = findingsPrinter;
@@ -104,7 +105,7 @@ public class FindingsMojo extends AbstractDependencyTrackMojo {
     protected void performAction() throws MojoExecutionException, MojoFailureException {
         List<Finding> findings;
         try {
-            Project project = projectAction.getProject(commonConfig);
+            Project project = projectAction.getProject(moduleConfig);
             findings = findingsAction.getFindings(project);
             findingsPrinter.printFindings(project, findings);
             populateThresholdFromCliOptions();

--- a/src/main/java/io/github/pmckeown/dependencytrack/metrics/MetricsMojo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/metrics/MetricsMojo.java
@@ -3,6 +3,7 @@ package io.github.pmckeown.dependencytrack.metrics;
 import io.github.pmckeown.dependencytrack.AbstractDependencyTrackMojo;
 import io.github.pmckeown.dependencytrack.CommonConfig;
 import io.github.pmckeown.dependencytrack.DependencyTrackException;
+import io.github.pmckeown.dependencytrack.ModuleConfig;
 import io.github.pmckeown.dependencytrack.project.Project;
 import io.github.pmckeown.dependencytrack.project.ProjectAction;
 import io.github.pmckeown.util.Logger;
@@ -23,15 +24,15 @@ import javax.inject.Inject;
  * For example the following configuration with fail the build if there are any Critical or High issues found in the
  * scan, more than 10 medium issues or more than 20 low issues.
  *
- * &lt;configuration&gt;
- *     &lt;metricsThresholds&gt;
- *         &lt;critical&gt;0&lt;/critical&gt;
- *         &lt;high&gt;0&lt;/high&gt;
- *         &lt;medium&gt;10&lt;/medium&gt;
- *         &lt;low&gt;20&lt;/low&gt;
- *         &lt;unassigned&gt;30&lt;/unassigned&gt;
- *     &lt;/metricsThresholds&gt;
- * &lt;/configuration&gt;
+ *  &lt;configuration&gt;
+ *      &lt;metricsThresholds&gt;
+ *          &lt;critical&gt;0&lt;/critical&gt;
+ *          &lt;high&gt;0&lt;/high&gt;
+ *          &lt;medium&gt;10&lt;/medium&gt;
+ *          &lt;low&gt;20&lt;/low&gt;
+ *          &lt;unassigned&gt;30&lt;/unassigned&gt;
+ *      &lt;/metricsThresholds&gt;
+ *  &lt;/configuration&gt;
  *
  * This allows you to tune build failures to your risk appetite.
  *
@@ -64,8 +65,8 @@ public class MetricsMojo extends AbstractDependencyTrackMojo {
 
     @Inject
     public MetricsMojo(MetricsAction metricsAction, ProjectAction getProjectAction, MetricsPrinter metricsPrinter,
-           MetricsAnalyser metricsAnalyser, CommonConfig commonConfig, Logger logger) {
-        super(commonConfig, logger);
+                       MetricsAnalyser metricsAnalyser, CommonConfig commonConfig, ModuleConfig moduleConfig, Logger logger) {
+        super(commonConfig, moduleConfig, logger);
         this.metricsAction = metricsAction;
         this.getProjectAction = getProjectAction;
         this.metricsPrinter = metricsPrinter;
@@ -75,7 +76,7 @@ public class MetricsMojo extends AbstractDependencyTrackMojo {
     @Override
     public void performAction() throws MojoExecutionException, MojoFailureException {
         try {
-            Project project = getProjectAction.getProject(commonConfig);
+            Project project = getProjectAction.getProject(moduleConfig);
             logger.debug("Project Details: %s", project.toString());
 
             Metrics metrics = getMetrics(project);

--- a/src/main/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsMojo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsMojo.java
@@ -3,6 +3,7 @@ package io.github.pmckeown.dependencytrack.policyviolation;
 import io.github.pmckeown.dependencytrack.AbstractDependencyTrackMojo;
 import io.github.pmckeown.dependencytrack.CommonConfig;
 import io.github.pmckeown.dependencytrack.DependencyTrackException;
+import io.github.pmckeown.dependencytrack.ModuleConfig;
 import io.github.pmckeown.dependencytrack.policyviolation.report.PolicyViolationsReportGenerator;
 import io.github.pmckeown.dependencytrack.project.Project;
 import io.github.pmckeown.dependencytrack.project.ProjectAction;
@@ -24,14 +25,14 @@ import static org.apache.maven.plugins.annotations.LifecyclePhase.VERIFY;
  * Print the policy violations retrieved from the Dependency Track Server after a BOM upload.  This is calculated
  * immediately by the server and as such can be used in situations where you want to know if a change to your
  * application pom.xml has breached a Policy defined on the Dependency Track server.
- *
+ * <p>
  * The build will fail if any Policies are breached that are configured with a violation state of FAIL.
- *
+ * <p>
  * The build will pass if any Policies are breached that are configured with a violation state of INFO.
- *
+ * <p>
  * The build will pass if any Policies are breached that are configured with a violation state of WARN unless the
  * `failOnWarn` option is supplied.
- *
+ * <p>
  * This allows you to tune build failures to your risk appetite.
  *
  * @author Sahiba Mittal
@@ -54,9 +55,9 @@ public class PolicyViolationsMojo extends AbstractDependencyTrackMojo {
 
     @Inject
     public PolicyViolationsMojo(ProjectAction projectAction, PolicyViolationsReportGenerator policyViolationReportGenerator,
-            CommonConfig commonConfig, Logger logger, PolicyViolationsAction policyAction,
-            PolicyViolationsPrinter policyViolationsPrinter, PolicyViolationsAnalyser policyAnalyser) {
-        super(commonConfig, logger);
+                                CommonConfig commonConfig, ModuleConfig moduleConfig, Logger logger, PolicyViolationsAction policyAction,
+                                PolicyViolationsPrinter policyViolationsPrinter, PolicyViolationsAnalyser policyAnalyser) {
+        super(commonConfig, moduleConfig, logger);
         this.projectAction = projectAction;
         this.policyViolationReportGenerator = policyViolationReportGenerator;
         this.policyAction = policyAction;
@@ -68,7 +69,7 @@ public class PolicyViolationsMojo extends AbstractDependencyTrackMojo {
     protected void performAction() throws MojoExecutionException, MojoFailureException {
         List<PolicyViolation> policyViolations;
         try {
-            Project project = projectAction.getProject(commonConfig);
+            Project project = projectAction.getProject(moduleConfig);
             policyViolations = policyAction.getPolicyViolations(project);
             policyViolationsPrinter.printPolicyViolations(project, policyViolations);
             boolean policyViolationsBreached = policyAnalyser.isAnyPolicyViolationBreached(policyViolations,
@@ -86,8 +87,7 @@ public class PolicyViolationsMojo extends AbstractDependencyTrackMojo {
     private File getOutputDirectory() {
         if (mavenProject == null) {
             return null;
-        }
-        else {
+        } else {
             return new File(mavenProject.getBuild().getDirectory());
         }
     }

--- a/src/main/java/io/github/pmckeown/dependencytrack/project/DeleteProjectMojo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/project/DeleteProjectMojo.java
@@ -3,6 +3,7 @@ package io.github.pmckeown.dependencytrack.project;
 import io.github.pmckeown.dependencytrack.AbstractDependencyTrackMojo;
 import io.github.pmckeown.dependencytrack.CommonConfig;
 import io.github.pmckeown.dependencytrack.DependencyTrackException;
+import io.github.pmckeown.dependencytrack.ModuleConfig;
 import io.github.pmckeown.util.Logger;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -23,25 +24,25 @@ public class DeleteProjectMojo extends AbstractDependencyTrackMojo {
     private ProjectAction projectAction;
 
     @Inject
-    public DeleteProjectMojo(ProjectAction projectAction, CommonConfig commonConfig, Logger logger) {
-        super(commonConfig, logger);
+    public DeleteProjectMojo(ProjectAction projectAction, CommonConfig commonConfig, ModuleConfig moduleConfig, Logger logger) {
+        super(commonConfig, moduleConfig, logger);
         this.projectAction = projectAction;
     }
 
     @Override
     protected void performAction() throws MojoExecutionException, MojoFailureException {
         try {
-            Project project = projectAction.getProject(commonConfig);
+            Project project = projectAction.getProject(moduleConfig);
 
             boolean success = projectAction.deleteProject(project);
 
             if (!success) {
-                handleFailure(format("Failed to delete project: %s-%s", commonConfig.getProjectName(),
-                        commonConfig.getProjectVersion()));
+                handleFailure(format("Failed to delete project: %s-%s", moduleConfig.getProjectName(),
+                        moduleConfig.getProjectVersion()));
             }
         } catch (DependencyTrackException ex) {
             handleFailure(format("Exception occurred while trying to delete project: %s-%s",
-                    commonConfig.getProjectName(), commonConfig.getProjectVersion()), ex);
+                    moduleConfig.getProjectName(), moduleConfig.getProjectVersion()), ex);
         }
     }
 }

--- a/src/main/java/io/github/pmckeown/dependencytrack/project/ProjectAction.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/project/ProjectAction.java
@@ -1,9 +1,9 @@
 package io.github.pmckeown.dependencytrack.project;
 
 import com.networknt.schema.utils.StringUtils;
-import io.github.pmckeown.dependencytrack.CommonConfig;
 import io.github.pmckeown.dependencytrack.DependencyTrackException;
 import io.github.pmckeown.dependencytrack.Item;
+import io.github.pmckeown.dependencytrack.ModuleConfig;
 import io.github.pmckeown.dependencytrack.Response;
 import io.github.pmckeown.dependencytrack.bom.BomParser;
 import io.github.pmckeown.util.Logger;
@@ -12,11 +12,7 @@ import kong.unirest.UnirestException;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.io.File;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
@@ -25,7 +21,6 @@ import static java.lang.String.format;
 public class ProjectAction {
 
     private ProjectClient projectClient;
-
     private BomParser bomParser;
     private Logger logger;
 
@@ -36,11 +31,11 @@ public class ProjectAction {
         this.logger = logger;
     }
 
-    public Project getProject(CommonConfig commonConfig) throws DependencyTrackException {
+    public Project getProject(ModuleConfig moduleConfig) throws DependencyTrackException {
         return getProject(
-            commonConfig.getProjectUuid(),
-            commonConfig.getProjectName(),
-            commonConfig.getProjectVersion());
+                moduleConfig.getProjectUuid(),
+                moduleConfig.getProjectName(),
+                moduleConfig.getProjectVersion());
     }
 
     public Project getProject(String uuid) throws DependencyTrackException {
@@ -62,12 +57,12 @@ public class ProjectAction {
                 } else {
                     if (StringUtils.isBlank(uuid)) {
                         throw new DependencyTrackException(
-                            format("Requested project not found by UUUID: %s", uuid)
+                                format("Requested project not found by UUUID: %s", uuid)
                         );
                     } else {
                         throw new DependencyTrackException(
-                            format("Requested project not found by name/version: %s-%s", name, version)
-                            );
+                                format("Requested project not found by name/version: %s-%s", name, version)
+                        );
                     }
                 }
             } else {
@@ -146,7 +141,7 @@ public class ProjectAction {
 
             Response<?> response = projectClient.deleteProject(project);
             return response.isSuccess();
-        } catch(UnirestException ex) {
+        } catch (UnirestException ex) {
             logger.error("Failed to delete project", ex);
             throw new DependencyTrackException("Failed to delete project");
         }

--- a/src/main/java/io/github/pmckeown/dependencytrack/score/ScoreAction.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/score/ScoreAction.java
@@ -2,6 +2,7 @@ package io.github.pmckeown.dependencytrack.score;
 
 import io.github.pmckeown.dependencytrack.CommonConfig;
 import io.github.pmckeown.dependencytrack.DependencyTrackException;
+import io.github.pmckeown.dependencytrack.ModuleConfig;
 import io.github.pmckeown.dependencytrack.Response;
 import io.github.pmckeown.dependencytrack.metrics.Metrics;
 import io.github.pmckeown.dependencytrack.metrics.MetricsAction;
@@ -26,21 +27,19 @@ class ScoreAction {
 
     private ProjectClient projectClient;
     private MetricsAction metricsAction;
-    private CommonConfig commonConfig = new CommonConfig();
     private Logger logger;
 
     @Inject
     public ScoreAction(ProjectClient projectClient, MetricsAction metricsAction, CommonConfig commonConfig,
-           Logger logger) {
+                       Logger logger) {
         this.projectClient = projectClient;
         this.metricsAction = metricsAction;
-        this.commonConfig = commonConfig;
         this.logger = logger;
     }
 
-    Integer determineScore(Integer inheritedRiskScoreThreshold) throws DependencyTrackException {
+    Integer determineScore(ModuleConfig moduleConfig, Integer inheritedRiskScoreThreshold) throws DependencyTrackException {
         try {
-            Response<Project> response = projectClient.getProject(commonConfig.getProjectUuid(), commonConfig.getProjectName(), commonConfig.getProjectVersion());
+            Response<Project> response = projectClient.getProject(moduleConfig.getProjectUuid(), moduleConfig.getProjectName(), moduleConfig.getProjectVersion());
 
             Optional<Project> body = response.getBody();
             if (response.isSuccess() && body.isPresent()) {
@@ -90,10 +89,4 @@ class ScoreAction {
         logger.info(DELIMITER);
     }
 
-    /*
-     * Setters for dependency injection in tests
-     */
-    void setCommonConfig(CommonConfig commonConfig) {
-        this.commonConfig = commonConfig;
-    }
 }

--- a/src/main/java/io/github/pmckeown/dependencytrack/score/ScoreMojo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/score/ScoreMojo.java
@@ -1,8 +1,9 @@
 package io.github.pmckeown.dependencytrack.score;
 
-import io.github.pmckeown.dependencytrack.CommonConfig;
 import io.github.pmckeown.dependencytrack.AbstractDependencyTrackMojo;
+import io.github.pmckeown.dependencytrack.CommonConfig;
 import io.github.pmckeown.dependencytrack.DependencyTrackException;
+import io.github.pmckeown.dependencytrack.ModuleConfig;
 import io.github.pmckeown.util.Logger;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -16,7 +17,7 @@ import static java.lang.String.format;
 
 /**
  * Provides the capability to find the current Inherited Risk Score as determined by the Dependency Track Server.
- *
+ * 
  * Specific configuration options are:
  * <ol>
  *     <li>inheritedRiskScoreThreshold</li>
@@ -33,19 +34,19 @@ public class ScoreMojo extends AbstractDependencyTrackMojo {
     private ScoreAction scoreAction;
 
     @Inject
-    public ScoreMojo(ScoreAction scoreAction, CommonConfig commonConfig, Logger logger) {
-        super(commonConfig, logger);
+    public ScoreMojo(ScoreAction scoreAction, ModuleConfig moduleConfig, CommonConfig commonConfig, Logger logger) {
+        super(commonConfig, moduleConfig, logger);
         this.scoreAction = scoreAction;
     }
 
     @Override
     public void performAction() throws MojoFailureException, MojoExecutionException {
         try {
-            Integer inheritedRiskScore = scoreAction.determineScore(inheritedRiskScoreThreshold);
+            Integer inheritedRiskScore = scoreAction.determineScore(moduleConfig, inheritedRiskScoreThreshold);
             failBuildIfThresholdIsBreached(inheritedRiskScore);
         } catch (DependencyTrackException ex) {
-            handleFailure(format("Failed to determine score for: %s-%s", commonConfig.getProjectName(),
-                    commonConfig.getProjectVersion()));
+            handleFailure(format("Failed to determine score for: %s-%s", moduleConfig.getProjectName(),
+                    moduleConfig.getProjectVersion()));
         }
     }
 

--- a/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomRequest.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomRequest.java
@@ -1,13 +1,12 @@
 package io.github.pmckeown.dependencytrack.upload;
 
-import io.github.pmckeown.dependencytrack.CommonConfig;
-import java.util.List;
-import java.util.stream.Collectors;
-
+import io.github.pmckeown.dependencytrack.ModuleConfig;
+import io.github.pmckeown.dependencytrack.project.ProjectTag;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
-import io.github.pmckeown.dependencytrack.project.ProjectTag;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Encapsulates the request payload for uploading a BOM
@@ -26,20 +25,20 @@ public class UploadBomRequest {
     private final String parentName;
     private final String parentVersion;
 
-    UploadBomRequest(CommonConfig commonConfig, String base64EncodedBom) {
-        this.projectName = commonConfig.getProjectName();
-        this.projectVersion = commonConfig.getProjectVersion();
-        this.autoCreate = commonConfig.isAutoCreate();
+    UploadBomRequest(ModuleConfig moduleConfig, String base64EncodedBom) {
+        this.projectName = moduleConfig.getProjectName();
+        this.projectVersion = moduleConfig.getProjectVersion();
+        this.autoCreate = moduleConfig.isAutoCreate();
         this.base64EncodedBom = base64EncodedBom;
-        this.isLatest = commonConfig.isLatest();
-        if (commonConfig.getProjectTags() == null) {
+        this.isLatest = moduleConfig.isLatest();
+        if (moduleConfig.getProjectTags() == null) {
             this.projectTags = null;
         } else {
-            this.projectTags = commonConfig.getProjectTags().stream().map(ProjectTag::new).collect(Collectors.toList());
+            this.projectTags = moduleConfig.getProjectTags().stream().map(ProjectTag::new).collect(Collectors.toList());
         }
-        this.parentUUID = commonConfig.getParentUuid();
-        this.parentName = commonConfig.getParentName();
-        this.parentVersion = commonConfig.getParentVersion();
+        this.parentUUID = moduleConfig.getParentUuid();
+        this.parentName = moduleConfig.getParentName();
+        this.parentVersion = moduleConfig.getParentVersion();
     }
 
     public String getProjectName() {

--- a/src/test/java/io/github/pmckeown/dependencytrack/AbstractDependencyTrackIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/AbstractDependencyTrackIntegrationTest.java
@@ -35,11 +35,16 @@ public abstract class AbstractDependencyTrackIntegrationTest {
 
     protected CommonConfig getCommonConfig() {
         CommonConfig config = new CommonConfig();
-        config.setProjectName(PROJECT_NAME);
-        config.setProjectVersion(PROJECT_VERSION);
         config.setDependencyTrackBaseUrl(HOST + wireMockRule.port());
         config.setApiKey(API_KEY);
         config.setPollingConfig(PollingConfig.disabled());
+        return config;
+    }
+
+    protected ModuleConfig getModuleConfig() {
+        ModuleConfig config = new ModuleConfig();
+        config.setProjectName(PROJECT_NAME);
+        config.setProjectVersion(PROJECT_VERSION);
         return config;
     }
 

--- a/src/test/java/io/github/pmckeown/dependencytrack/ConfigTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/ConfigTest.java
@@ -1,11 +1,5 @@
 package io.github.pmckeown.dependencytrack;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.doReturn;
-
-import java.io.File;
 import org.apache.maven.project.MavenProject;
 import org.junit.Before;
 import org.junit.Test;
@@ -14,8 +8,15 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.io.File;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.doReturn;
+
 @RunWith(MockitoJUnitRunner.class)
-public class CommonConfigTest {
+public class ConfigTest {
 
     private static final String PROJECT_NAME = "test";
 
@@ -25,19 +26,19 @@ public class CommonConfigTest {
     private MavenProject project;
 
     @InjectMocks
-    private CommonConfig commonConfig;
+    private ModuleConfig moduleConfig;
 
     @Before
     public void setup() {
-        commonConfig = new CommonConfig();
-        commonConfig.setMavenProject(project);
+        moduleConfig = new ModuleConfig();
+        moduleConfig.setMavenProject(project);
     }
 
     @Test
     public void thatTheBomLocationIsDefaultedWhenNotSupplied() {
         doReturn(new File(".")).when(project).getBasedir();
 
-        assertThat(commonConfig.getBomLocation(), is(equalTo("./target/bom.xml")));
-        assertThat(commonConfig.isLatest(), is(equalTo(false)));
+        assertThat(moduleConfig.getBomLocation(), is(equalTo("./target/bom.xml")));
+        assertThat(moduleConfig.isLatest(), is(equalTo(false)));
     }
 }

--- a/src/test/java/io/github/pmckeown/dependencytrack/finding/FindingsMojoTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/finding/FindingsMojoTest.java
@@ -1,6 +1,7 @@
 package io.github.pmckeown.dependencytrack.finding;
 
 import io.github.pmckeown.dependencytrack.CommonConfig;
+import io.github.pmckeown.dependencytrack.ModuleConfig;
 import io.github.pmckeown.dependencytrack.finding.report.FindingsReportGenerator;
 import io.github.pmckeown.dependencytrack.project.ProjectAction;
 import io.github.pmckeown.util.Logger;
@@ -14,16 +15,11 @@ import org.mockito.junit.MockitoJUnitRunner;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.*;
 
 @SuppressWarnings("unused")
 @RunWith(MockitoJUnitRunner.class)
@@ -46,6 +42,9 @@ public class FindingsMojoTest {
 
     @Mock
     private CommonConfig commonConfig;
+
+    @Mock
+    private ModuleConfig moduleConfig;
 
     @Mock
     private FindingsReportGenerator findingsReportGenerator;

--- a/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsMojoTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsMojoTest.java
@@ -1,6 +1,7 @@
 package io.github.pmckeown.dependencytrack.policyviolation;
 
 import io.github.pmckeown.dependencytrack.CommonConfig;
+import io.github.pmckeown.dependencytrack.ModuleConfig;
 import io.github.pmckeown.dependencytrack.policyviolation.report.PolicyViolationsReportGenerator;
 import io.github.pmckeown.dependencytrack.project.ProjectAction;
 import io.github.pmckeown.util.Logger;
@@ -12,9 +13,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.ArrayList;
 
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.*;
 
 @SuppressWarnings("unused")
 @RunWith(MockitoJUnitRunner.class)
@@ -37,6 +36,9 @@ public class PolicyViolationsMojoTest {
 
     @Mock
     private CommonConfig commonConfig;
+
+    @Mock
+    private ModuleConfig moduleConfig;
 
     @Mock
     private PolicyViolationsReportGenerator policyViolationReportGenerator;

--- a/src/test/java/io/github/pmckeown/dependencytrack/project/ProjectActionTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/project/ProjectActionTest.java
@@ -2,6 +2,7 @@ package io.github.pmckeown.dependencytrack.project;
 
 import io.github.pmckeown.dependencytrack.CommonConfig;
 import io.github.pmckeown.dependencytrack.DependencyTrackException;
+import io.github.pmckeown.dependencytrack.ModuleConfig;
 import io.github.pmckeown.dependencytrack.Response;
 import io.github.pmckeown.dependencytrack.bom.BomParser;
 import io.github.pmckeown.util.Logger;
@@ -13,23 +14,12 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.File;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 
 import static io.github.pmckeown.dependencytrack.ResponseBuilder.aSuccessResponse;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
@@ -46,7 +36,7 @@ public class ProjectActionTest {
     private ProjectAction projectAction;
 
     @Mock
-    private CommonConfig commonConfig1;
+    private CommonConfig commonConfig;
 
     @Mock
     private ProjectClient projectClient;
@@ -61,7 +51,7 @@ public class ProjectActionTest {
     public void thatProjectCanBeRetrievedByCommonConfig() throws Exception {
         doReturn(aSuccessResponse().withBody(project2()).build()).when(projectClient).getProject(anyString(), anyString(), anyString());
 
-        Project project = projectAction.getProject(commonConfig1());
+        Project project = projectAction.getProject(getModuleConfig());
 
         assertThat(project, is(not(nullValue())));
         assertThat(project.getUuid(), is(equalTo(UUID_2)));
@@ -92,7 +82,7 @@ public class ProjectActionTest {
         doThrow(UnirestException.class).when(projectClient).getProject(anyString(), anyString(), anyString());
 
         try {
-            projectAction.getProject(commonConfig1());
+            projectAction.getProject(getModuleConfig());
         } catch (Exception ex) {
             assertThat(ex, is(instanceOf(DependencyTrackException.class)));
         }
@@ -102,7 +92,7 @@ public class ProjectActionTest {
     public void thatANotFoundResponseResultsInAnException() throws DependencyTrackException {
         doReturn(aNotFoundResponse()).when(projectClient).getProject(anyString(), anyString(), anyString());
 
-        projectAction.getProject(commonConfig1());
+        projectAction.getProject(getModuleConfig());
     }
 
     @Test
@@ -110,7 +100,7 @@ public class ProjectActionTest {
         doReturn(aSuccessResponse().build()).when(projectClient).getProject(anyString(), anyString(), anyString());
 
         try {
-            projectAction.getProject(commonConfig1());
+            projectAction.getProject(getModuleConfig());
         } catch (Exception ex) {
             assertThat(ex, is(instanceOf(DependencyTrackException.class)));
         }
@@ -120,7 +110,7 @@ public class ProjectActionTest {
     public void thatRequestedProjectCannotBeFoundAnExceptionIsThrown() throws DependencyTrackException {
         doReturn(aSuccessResponse().build()).when(projectClient).getProject(anyString(), anyString(), anyString());
 
-        projectAction.getProject(commonConfig1());
+        projectAction.getProject(getModuleConfig());
     }
 
     @Test
@@ -254,10 +244,10 @@ public class ProjectActionTest {
         return new Project(UUID_2, PROJECT_NAME_2, PROJECT_VERSION_2, null, false, tags);
     }
 
-    private CommonConfig commonConfig1() {
-        CommonConfig commonConfig = new CommonConfig();
-        commonConfig.setProjectName(PROJECT_NAME_2);
-        commonConfig.setProjectVersion(PROJECT_VERSION_2);
-        return commonConfig;
+    private ModuleConfig getModuleConfig() {
+        ModuleConfig moduleConfig = new ModuleConfig();
+        moduleConfig.setProjectName(PROJECT_NAME_2);
+        moduleConfig.setProjectVersion(PROJECT_VERSION_2);
+        return moduleConfig;
     }
 }

--- a/src/test/java/io/github/pmckeown/dependencytrack/project/ProjectClientIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/project/ProjectClientIntegrationTest.java
@@ -2,6 +2,7 @@ package io.github.pmckeown.dependencytrack.project;
 
 import io.github.pmckeown.dependencytrack.AbstractDependencyTrackMojoTest;
 import io.github.pmckeown.dependencytrack.CommonConfig;
+import io.github.pmckeown.dependencytrack.ModuleConfig;
 import io.github.pmckeown.dependencytrack.Response;
 import kong.unirest.HttpStatus;
 import org.junit.Before;
@@ -11,22 +12,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
-import static com.github.tomakehurst.wiremock.client.WireMock.patch;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.patchRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.verify;
-import static io.github.pmckeown.dependencytrack.TestResourceConstants.V1_PROJECT_UUID;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static io.github.pmckeown.dependencytrack.ResourceConstants.V1_PROJECT_LOOKUP;
+import static io.github.pmckeown.dependencytrack.TestResourceConstants.V1_PROJECT_UUID;
 import static io.github.pmckeown.dependencytrack.project.ProjectInfoBuilder.aProjectInfo;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.doReturn;
 
@@ -38,6 +29,9 @@ public class ProjectClientIntegrationTest extends AbstractDependencyTrackMojoTes
 
     @Mock
     private CommonConfig commonConfig;
+
+    @Mock
+    private ModuleConfig moduleConfig;
 
     @Before
     public void setUp() {
@@ -57,14 +51,14 @@ public class ProjectClientIntegrationTest extends AbstractDependencyTrackMojoTes
 
     @Test
     public void thatProjectParsingWorks() {
-        doReturn("doesn't matter").when(commonConfig).getProjectName();
-        doReturn("doesn't matter").when(commonConfig).getProjectVersion();
+        doReturn("doesn't matter").when(moduleConfig).getProjectName();
+        doReturn("doesn't matter").when(moduleConfig).getProjectVersion();
         stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP)).willReturn(
-            aResponse()
-                .withStatus(HttpStatus.OK)
-                .withBodyFile("api/v1/project/tags-project.json")));
+                aResponse()
+                        .withStatus(HttpStatus.OK)
+                        .withBodyFile("api/v1/project/tags-project.json")));
 
-        Response<Project> response = projectClient.getProject(commonConfig.getProjectUuid(), commonConfig.getProjectName(), commonConfig.getProjectVersion());
+        Response<Project> response = projectClient.getProject(moduleConfig.getProjectUuid(), moduleConfig.getProjectName(), moduleConfig.getProjectVersion());
         assertThat(response.isSuccess(), is(equalTo(true)));
         assertThat(response.getBody().isPresent(), is(equalTo(true)));
         Project project = response.getBody().get();

--- a/src/test/java/io/github/pmckeown/dependencytrack/upload/BomClientIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/upload/BomClientIntegrationTest.java
@@ -8,26 +8,14 @@ import kong.unirest.UnirestException;
 import org.junit.Before;
 import org.junit.Test;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
-import static com.github.tomakehurst.wiremock.client.WireMock.notFound;
-import static com.github.tomakehurst.wiremock.client.WireMock.ok;
-import static com.github.tomakehurst.wiremock.client.WireMock.put;
-import static com.github.tomakehurst.wiremock.client.WireMock.putRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.status;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
-import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static io.github.pmckeown.dependencytrack.ResourceConstants.V1_BOM;
 import static io.github.pmckeown.dependencytrack.TestResourceConstants.V1_BOM_TOKEN_UUID;
 import static io.github.pmckeown.dependencytrack.TestUtils.asJson;
 import static io.github.pmckeown.dependencytrack.upload.BomProcessingResponseBuilder.aBomProcessingResponse;
 import static io.github.pmckeown.dependencytrack.upload.UploadBomResponseBuilder.anUploadBomResponse;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -119,6 +107,6 @@ public class BomClientIntegrationTest extends AbstractDependencyTrackIntegration
      */
 
     private UploadBomRequest aBom() {
-        return new UploadBomRequest(getCommonConfig(), BASE_64_ENCODED_BOM);
+        return new UploadBomRequest(getModuleConfig(), BASE_64_ENCODED_BOM);
     }
 }

--- a/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoTest.java
@@ -1,6 +1,7 @@
 package io.github.pmckeown.dependencytrack.upload;
 
 import io.github.pmckeown.dependencytrack.CommonConfig;
+import io.github.pmckeown.dependencytrack.ModuleConfig;
 import io.github.pmckeown.dependencytrack.metrics.MetricsAction;
 import io.github.pmckeown.dependencytrack.project.ProjectAction;
 import io.github.pmckeown.util.Logger;
@@ -13,15 +14,12 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+
 import java.util.Collections;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class UploadBomMojoTest {
@@ -51,9 +49,13 @@ public class UploadBomMojoTest {
     @Mock
     private CommonConfig commonConfig;
 
+    @Mock
+    private ModuleConfig moduleConfig;
+
     @Before
     public void setup() {
         uploadBomMojo.setCommonConfig(commonConfig);
+        uploadBomMojo.setModuleConfig(moduleConfig);
         uploadBomMojo.setMavenProject(project);
     }
 
@@ -65,8 +67,8 @@ public class UploadBomMojoTest {
 
         uploadBomMojo.execute();
 
-        verify(commonConfig).setProjectName(PROJECT_NAME);
-        verify(commonConfig).setProjectVersion(PROJECT_VERSION);
+        verify(moduleConfig).setProjectName(PROJECT_NAME);
+        verify(moduleConfig).setProjectVersion(PROJECT_VERSION);
         verifyNoInteractions(uploadBomAction);
         verifyNoInteractions(metricsAction);
         verifyNoInteractions(projectAction);
@@ -80,8 +82,8 @@ public class UploadBomMojoTest {
 
         uploadBomMojo.execute();
 
-        verify(commonConfig).setProjectName(PROJECT_NAME);
-        verify(commonConfig).setProjectVersion(PROJECT_VERSION);
+        verify(moduleConfig).setProjectName(PROJECT_NAME);
+        verify(moduleConfig).setProjectVersion(PROJECT_VERSION);
         verifyNoInteractions(uploadBomAction);
         verifyNoInteractions(metricsAction);
         verifyNoInteractions(projectAction);
@@ -96,8 +98,8 @@ public class UploadBomMojoTest {
 
         uploadBomMojo.execute();
 
-        verify(commonConfig).setProjectName(PROJECT_NAME);
-        verify(commonConfig).setProjectVersion(snapshotVersion);
+        verify(moduleConfig).setProjectName(PROJECT_NAME);
+        verify(moduleConfig).setProjectVersion(snapshotVersion);
         verifyNoInteractions(uploadBomAction);
         verifyNoInteractions(metricsAction);
         verifyNoInteractions(projectAction);
@@ -119,14 +121,14 @@ public class UploadBomMojoTest {
 
     @Test
     public void thatWhenUpdateParentFailsTheLoggerIsCalledAndBuildFails() throws Exception {
-        doReturn(true).when(uploadBomAction).upload();
-
-        CommonConfig config = new CommonConfig();
+        ModuleConfig config = new ModuleConfig();
         config.setProjectName("project-parent");
         config.setProjectVersion("1.2.3");
         config.setUpdateParent(true);
 
-        uploadBomMojo.setCommonConfig(config);
+        doReturn(true).when(uploadBomAction).upload(config);
+
+        uploadBomMojo.setModuleConfig(config);
         uploadBomMojo.setParentName("project-parent");
         uploadBomMojo.setParentVersion("1.2.3");
         uploadBomMojo.setUpdateParent(true);
@@ -144,7 +146,7 @@ public class UploadBomMojoTest {
 
     @Test
     public void thatUpdateParentFailsWhenParentNameIsNull() throws Exception {
-        doReturn(true).when(uploadBomAction).upload();
+        doReturn(true).when(uploadBomAction).upload(moduleConfig);
 
         uploadBomMojo.setParentName(null);
         uploadBomMojo.setParentVersion(null);


### PR DESCRIPTION
Closes #435.

Pulled out parameters from CommonConfig into ModuleConfig that can be different from module to module. The difference between those two config-classes is that ModuleConfig is not a singleton. Also updated the wiremock dependency which has been moved to org.wiremock.

The issues I had were resolved through the changes, but I'm not confident to mark the goals as thread-safe, more extensive testing would be needed.