### PR TITLE
Improved default configuration handling (#442)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,15 @@ The skip property has more than two possible values:
  * snapshots: will skip if current version of the project is a snapshot
  * any other values will be considered as false
 
+#### Dependency-Track Plugin/Server Compatibility
+
+| Plugin Version | Required Server Version | Features                |
+|----------------|-------------------------|-------------------------|
+| 1.9.2          | 4.8.0                   | Project parent          |
+|                | 4.12.0                  | isLatest, projectTags   |
+
+*Note:* certain plugin features are not available in older server versions.
+
 ## Features
 
 * [Upload Bill of Material](#upload-bill-of-material) - Create/modify a project on the Dependency-Track server, as well
@@ -237,12 +246,14 @@ Dependency-Track based on the metadata present in the BOM:
 
 From Dependency-Track server 4.8.0 onwards, you can set the project parent by setting `updateParent` to `true`. The 
 parent name will be defaulted to that POM's project parent name. If you wish to override that value, or there is 
-no parent set within the `pom.xml`, then explicitly set `parentName` and `parentVersion`. `projectVersion` is optional 
-Dependency-Track, so this has no default to allow for blank values.
+no parent set within the `pom.xml`, then explicitly set `parentName`. Both `parentName` and `parentVersion`
+must be configured, otherwise either value is omitted in the upload.
 
 **Note 1:** If both `parentUuid` and `parentName` / `parentVersion` are provided in configuration `parentUuid` will take precedence.
 
-**Note 2:** If a non-existing parent information is provided, the plugin will fail with `404 Not found`. 
+**Note 2:** If a non-existing parent information is provided, the plugin will fail with `404 Not found`.
+
+From Dependency-Track server 4.12.0 onwards you can set `isLatest` and `projectTags`.
 
 | Property           | Required | Default Value          | Example Values                        |
 |--------------------|----------|------------------------|---------------------------------------|
@@ -252,8 +263,8 @@ Dependency-Track, so this has no default to allow for blank values.
 | parentUuid         | false    |                        | 628df5eb-a7fe-4c3f-831c-4536839a05ed  |
 | parentName         | false    | ${project.parent.name} | my-name-override                      |
 | parentVersion      | false    |                        | ${project.parent.version}             |
-| isLatest           | false    | false                  | true                                  |
-| projectTags[].name | false    | false                  | <name>tag1</name>                     |
+| isLatest           | false    |                        | true                                  |
+| projectTags[].name | false    |                        | <name>tag1</name>                     |
 
 The `isLatest` option sets the flag on the project to indicate that it is the latest version.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://github.com/pmckeown/dependency-track-maven-plugin/actions/workflows/maven.yml/badge.svg)](https://github.com/pmckeown/dependency-track-maven-plugin/actions/workflows/maven/badge.svg)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.github.pmckeown/dependency-track-maven-plugin/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.github.pmckeown/dependency-track-maven-plugin)
+![Maven Central Version](https://img.shields.io/maven-central/v/io.github.pmckeown/dependency-track-maven-plugin)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=pmckeown_dependency-track-maven-plugin&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=pmckeown_dependency-track-maven-plugin)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/0e77d6dda095411ea178ce1246446188)](https://app.codacy.com/gh/pmckeown/dependency-track-maven-plugin?utm_source=github.com&utm_medium=referral&utm_content=pmckeown/dependency-track-maven-plugin&utm_campaign=Badge_Grade)
 
@@ -168,10 +168,10 @@ The skip property has more than two possible values:
 
 #### Dependency-Track Plugin/Server Compatibility
 
-| Plugin Version | Required Server Version | Features                |
-|----------------|-------------------------|-------------------------|
-| 1.9.2          | 4.8.0                   | Project parent          |
-|                | 4.12.0                  | isLatest, projectTags   |
+| Min Plugin Version | Required Server Version | Features                |
+|--------------------|-------------------------|-------------------------|
+| 1.5.0              | 4.8.0                   | Project parent          |
+| 1.10.0             | 4.12.0                  | isLatest, projectTags   |
 
 *Note:* certain plugin features are not available in older server versions.
 
@@ -188,7 +188,7 @@ quality control
 
 
 ### Upload Bill of Material
-Upload a Bill of Material (BOM) to a Dependency-Track server.  By default this uploads the bom.xml and creates (or 
+Upload a Bill of Material (BOM) to a Dependency-Track server.  By default, this uploads the bom.xml and creates (or
 updates if already present) a project on the Dependency-Track server with the name and version that map to the current
 maven project artifactId and version.  Set the projectName or projectVersion properties if you want to override the
 project name or version. 
@@ -246,12 +246,14 @@ Dependency-Track based on the metadata present in the BOM:
 
 From Dependency-Track server 4.8.0 onwards, you can set the project parent by setting `updateParent` to `true`. The 
 parent name will be defaulted to that POM's project parent name. If you wish to override that value, or there is 
-no parent set within the `pom.xml`, then explicitly set `parentName`. Both `parentName` and `parentVersion`
-must be configured, otherwise either value is omitted in the upload.
+no parent set within the `pom.xml`, then explicitly set `parentName`.
 
-**Note 1:** If both `parentUuid` and `parentName` / `parentVersion` are provided in configuration `parentUuid` will take precedence.
+**Note 1:** Both `parentName` and `parentVersion` must be configured, otherwise either value is omitted in the upload.
 
-**Note 2:** If a non-existing parent information is provided, the plugin will fail with `404 Not found`.
+**Note 2:** If both `parentUuid` and `parentName` / `parentVersion` are provided in configuration, `parentUuid` will
+take precedence.
+
+**Note 3:** If a non-existing parent information is provided, the plugin will fail with `404 Not found`.
 
 From Dependency-Track server 4.12.0 onwards you can set `isLatest` and `projectTags`.
 
@@ -337,14 +339,14 @@ whatever overridden values that are supplied.
 
 The `findings` goal supports the following XML configuration in the POM:
 
-|Property                    |Required|Default Value|Description                                                                                           |
-|----------------------------|--------|-------------|------------------------------------------------------------------------------------------------------|
-|findingThresholds           |false   |N/A          |If not set or no child elements set then no policy will be applied and the goal will always succeed   |
-|findingThresholds.critical  |false   |0            |The build will fail if the issue count is higher than the configured threshold value for this category|
-|findingThresholds.high      |false   |0            |The build will fail if the issue count is higher than the configured threshold value for this category|
-|findingThresholds.medium    |false   |0            |The build will fail if the issue count is higher than the configured threshold value for this category|
-|findingThresholds.low       |false   |0            |The build will fail if the issue count is higher than the configured threshold value for this category|
-|findingThresholds.unassigned|false   |0            |The build will fail if the issue count is higher than the configured threshold value for this category|
+| Property                     | Required | Default Value | Description                                                                                            |
+|------------------------------|----------|---------------|--------------------------------------------------------------------------------------------------------|
+| findingThresholds            | false    | N/A           | If not set or no child elements set then no policy will be applied and the goal will always succeed    |
+| findingThresholds.critical   | false    | 0             | The build will fail if the issue count is higher than the configured threshold value for this category |
+| findingThresholds.high       | false    | 0             | The build will fail if the issue count is higher than the configured threshold value for this category |
+| findingThresholds.medium     | false    | 0             | The build will fail if the issue count is higher than the configured threshold value for this category |
+| findingThresholds.low        | false    | 0             | The build will fail if the issue count is higher than the configured threshold value for this category |
+| findingThresholds.unassigned | false    | 0             | The build will fail if the issue count is higher than the configured threshold value for this category |
 
 The `findings` goal also supports the following command line options however XML configuration takes precedence if set:
 
@@ -424,9 +426,9 @@ Policy Violation requires your Automation Team to have additional permissions:
 
 #### Policy Configuration
 
-|Property                      |Required|Default Value |
-|------------------------------|--------|--------------|
-|failOnWarn                    |false   |false         |
+| Property   | Required | Default Value |
+|------------|----------|---------------|
+| failOnWarn | false    | false         |
 
 #### Behaviour
 
@@ -469,9 +471,9 @@ whatever overridden values that are supplied.
 
 #### Configuration
 
-|Property                   |Required|Default Value|
-|---------------------------|--------|-------------|
-|inheritedRiskScoreThreshold|false   |N/A          |
+| Property                    | Required | Default Value |
+|-----------------------------|----------|---------------|
+| inheritedRiskScoreThreshold | false    | N/A           |
 
 ### Get Metrics
 Get and print all metrics from the Dependency-Track server for the current project or any arbitrary project.  Optionally
@@ -496,13 +498,13 @@ whatever overridden values that are supplied.
 
 #### Configuration
 
-|Property                  |Required|Default Value|Description                                                                                           |
-|--------------------------|--------|-------------|------------------------------------------------------------------------------------------------------|
-|metricsThresholds         |false   |N/A          |If present with no child elements, any issues found in any category will cause the build to fail      |
-|metricsThresholds.critical|false   |0            |The build will fail if the issue count is higher than the configured threshold value for this category|
-|metricsThresholds.high    |false   |0            |The build will fail if the issue count is higher than the configured threshold value for this category|
-|metricsThresholds.medium  |false   |0            |The build will fail if the issue count is higher than the configured threshold value for this category|
-|metricsThresholds.low     |false   |0            |The build will fail if the issue count is higher than the configured threshold value for this category|
+| Property                   | Required | Default Value | Description                                                                                            |
+|----------------------------|----------|---------------|--------------------------------------------------------------------------------------------------------|
+| metricsThresholds          | false    | N/A           | If present with no child elements, any issues found in any category will cause the build to fail       |
+| metricsThresholds.critical | false    | 0             | The build will fail if the issue count is higher than the configured threshold value for this category |
+| metricsThresholds.high     | false    | 0             | The build will fail if the issue count is higher than the configured threshold value for this category |
+| metricsThresholds.medium   | false    | 0             | The build will fail if the issue count is higher than the configured threshold value for this category |
+| metricsThresholds.low      | false    | 0             | The build will fail if the issue count is higher than the configured threshold value for this category |
 
 Note that this goal does not yet support command line threshold options.
 

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -5,12 +5,24 @@ However, it is also useful to be able to test the project against a real Depende
 
 ## Integrated Testing
 
-### Running a Local Dependency Track
+### Running Latest Dependency Track Locally
 To run a Dependency Track server, the easiest option if you have Docker for Desktop installed is to use
 the Docker Compose command from the Dependency Track project.
 
 ```shell script
 curl --location --remote-name https://dependencytrack.org/docker-compose.yml
+docker compose up
+```
+
+### Running specific versions of Dependency Track Locally
+To run a specific version of a Dependency Track server, clone the git repo and check out the branch you want to run, 
+then run using docker compose. 
+
+```shell script
+git clone git@github.com:DependencyTrack/dependency-track.git
+cd dependency-track
+git checkout 4.12.x
+cd src/main/docker
 docker compose up
 ```
 

--- a/doc/TESTING.md
+++ b/doc/TESTING.md
@@ -1,7 +1,7 @@
 # Testing dependency-track-maven-plugin
-The project contains a number of unit and in-memory integration tests that verify the codebase.  
+The project contains a number of unit and in-memory integration tests that verify the codebase.
 
-However, it is also useful to be able to test the project against a real Dependency Track server.  
+However, it is also useful to be able to test the project against a real Dependency Track server.
 
 ## Integrated Testing
 
@@ -11,7 +11,7 @@ the Docker Compose command from the Dependency Track project.
 
 ```shell script
 curl --location --remote-name https://dependencytrack.org/docker-compose.yml
-docker-compose up
+docker compose up
 ```
 
 ### Running the Plugin against Dependency Track
@@ -25,9 +25,9 @@ file.  You will need to export or define a couple of environment variables for t
 ```shell script
 export DEPENDENCY_TRACK_BASE_URL=http://localhost:8081 
 export DEPENDENCY_TRACK_API_KEY=<YOUR_API_KEY> 
-mvn clean install -DskipTests -Peat-your-own-dog-food
+mvn clean verify -DskipTests -Peat-your-own-dog-food
 ```
 
 Notes:
 - The project tests can be skipped for the profile executions
-- The API backend port when using the `docker-compose up` from the Dependency Track project is by default `8081`  
+- The API backend port when using the `docker compose up` from the Dependency Track project is by default `8081`

--- a/pom.xml
+++ b/pom.xml
@@ -7,14 +7,15 @@
 
     <groupId>io.github.pmckeown</groupId>
     <artifactId>dependency-track-maven-plugin</artifactId>
-    <version>1.9.2-SNAPSHOT</version>
+    <version>1.10.0-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>Dependency Track Maven Plugin</name>
     <url>https://github.com/pmckeown/dependency-track-maven-plugin</url>
     <description>
-        Maven plugin to integrate with a Dependency Track server to submit dependency manifests and gather project metrics.  Can be used within
-        build pipelines to analyse the current project and optionally fail the build if vulnerabilities are found.
+        Maven plugin to integrate with a Dependency Track server to submit dependency manifests and gather project
+        metrics.  Can be used within build pipelines to analyse the current project and optionally fail the build if
+        vulnerabilities are found.
     </description>
     <inceptionYear>2019</inceptionYear>
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
         <maven.version>3.9.5</maven.version>
         <sonar.organization>pmckeown</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <cyclonedx-maven-plugin.version>2.7.10</cyclonedx-maven-plugin.version>
     </properties>
 
     <dependencies>
@@ -458,10 +459,10 @@
             2 properties must be set on the command line or as environment variables.
 
             Example usage with command args:
-            mvn clean install -Peat-your-own-dog-food -Ddependency-track.dependencyTrackBaseUrl -Ddependency-track.dependencyTrackApiKey
+            mvn clean verify -Peat-your-own-dog-food -Ddependency-track.dependencyTrackBaseUrl -Ddependency-track.dependencyTrackApiKey
 
             Example usage with environment variables set (DEPENDENCY_TRACK_BASE_URL & DEPENDENCY_TRACK_API_KEY):
-            mvn clean install -Peat-your-own-dog-food
+            mvn clean verify -Peat-your-own-dog-food
         -->
         <profile>
             <id>eat-your-own-dog-food</id>
@@ -470,7 +471,7 @@
                     <plugin>
                         <groupId>org.cyclonedx</groupId>
                         <artifactId>cyclonedx-maven-plugin</artifactId>
-                        <version>2.7.10</version>
+                        <version>${cyclonedx-maven-plugin.version}</version>
                         <configuration>
                             <schemaVersion>1.4</schemaVersion>
                             <includeBomSerialNumber>true</includeBomSerialNumber>
@@ -529,6 +530,48 @@
                                         <medium>0</medium>
                                         <low>0</low>
                                     </findingThresholds>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>3.6.0</version>
+                        <executions>
+                            <execution>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>timestamp-property</goal>
+                                </goals>
+                                <configuration>
+                                    <pattern>yyyyMMddHHmmss</pattern>
+                                    <name>it.snapshot.timestamp</name>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-invoker-plugin</artifactId>
+                        <version>3.9.0</version>
+                        <executions>
+                            <execution>
+                                <id>local-plugin-install</id>
+                                <goals>
+                                    <goal>install</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>integration-test</id>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <goals>
+                                        <goal>verify</goal>
+                                    </goals>
+                                    <skipInvocation>${skipITs}</skipInvocation>
                                 </configuration>
                             </execution>
                         </executions>

--- a/src/it/common-parent-project/README.md
+++ b/src/it/common-parent-project/README.md
@@ -1,0 +1,7 @@
+This defined a maven project which is used by other project as parent.
+It is used to have a common baseline for other projects within an organization.
+It defines standard plugin configurations.
+
+This project defines the dependency-track plugin and configuration, but it does not include it in its execution.
+
+As this project has no dependencies itself it has little place in Dependency Track.

--- a/src/it/common-parent-project/pom.xml
+++ b/src/it/common-parent-project/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.github.pmckeown.dtmp.tests</groupId>
+    <artifactId>common-parent-project</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <dependency-track-maven-plugin.version>@project.version@</dependency-track-maven-plugin.version>
+    </properties>
+
+    <build>
+        <pluginManagement>
+          <plugins>
+              <plugin>
+                  <groupId>org.cyclonedx</groupId>
+                  <artifactId>cyclonedx-maven-plugin</artifactId>
+                  <version>@cyclonedx-maven-plugin.version@</version>
+                  <inherited>true</inherited>
+                  <configuration>
+                      <schemaVersion>1.4</schemaVersion>
+                      <includeBomSerialNumber>true</includeBomSerialNumber>
+                      <includeCompileScope>true</includeCompileScope>
+                      <includeProvidedScope>true</includeProvidedScope>
+                      <includeRuntimeScope>true</includeRuntimeScope>
+                      <includeSystemScope>true</includeSystemScope>
+                      <includeTestScope>false</includeTestScope>
+                  </configuration>
+                  <executions>
+                      <execution>
+                          <id>generate-bom</id>
+                          <phase>verify</phase>
+                          <goals>
+                              <goal>makeBom</goal>
+                          </goals>
+                      </execution>
+                  </executions>
+              </plugin>
+              <plugin>
+                  <groupId>io.github.pmckeown</groupId>
+                  <artifactId>dependency-track-maven-plugin</artifactId>
+                  <version>${dependency-track-maven-plugin.version}</version>
+                  <inherited>true</inherited>
+                  <configuration>
+                      <dependencyTrackBaseUrl>${env.DEPENDENCY_TRACK_BASE_URL}</dependencyTrackBaseUrl>
+                      <apiKey>${env.DEPENDENCY_TRACK_API_KEY}</apiKey>
+                      <failOnError>true</failOnError>
+                  </configuration>
+                  <executions>
+                      <execution>
+                          <id>upload-bom</id>
+                          <phase>verify</phase>
+                          <goals>
+                              <goal>upload-bom</goal>
+                          </goals>
+                          <configuration>
+                              <updateProjectInfo>true</updateProjectInfo>
+                              <isLatest>true</isLatest>
+                              <projectTags>
+                                  <name>dog-food</name>
+                              </projectTags>
+                          </configuration>
+                      </execution>
+                  </executions>
+              </plugin>
+          </plugins>
+        </pluginManagement>
+    </build>
+</project>
+

--- a/src/it/project-with-parent/README.md
+++ b/src/it/project-with-parent/README.md
@@ -1,0 +1,6 @@
+A normal maven project which builds upon the common parent project.
+
+This project activates plugins from the parent project.
+
+The project has a ever changing version so that it will always try to upload a new
+version to Dependency Track. The parent version is fixed though.

--- a/src/it/project-with-parent/pom.xml
+++ b/src/it/project-with-parent/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.github.pmckeown.dtmp.tests</groupId>
+        <artifactId>common-parent-project</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../common-parent-project</relativePath>
+    </parent>
+    <artifactId>project-with-parent</artifactId>
+    <version>1.0.0-@it.snapshot.timestamp@</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.github.pmckeown</groupId>
+            <artifactId>dependency-track-maven-plugin</artifactId>
+            <version>${dependency-track-maven-plugin.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>io.github.pmckeown</groupId>
+                <artifactId>dependency-track-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+

--- a/src/it/simple-module-project-alt/README.md
+++ b/src/it/simple-module-project-alt/README.md
@@ -1,0 +1,11 @@
+This is a maven project with sub-modules. The submodule refers to the project's main project.
+
+The main maven project configures the dependency track plugin to be executed.
+As the submodule uses the main project as parent the child also executes the dependency track plugin.
+
+This configuration is slightly different from the simple-module-project as the submodule
+explicitly defines the `parentVersion` in the plugin configuration.
+This shows that the explicit parent configuration does not fail due to issue #441.
+
+The project has a ever changing version so that it will always try to upload a new
+version to Dependency Track.

--- a/src/it/simple-module-project-alt/child/pom.xml
+++ b/src/it/simple-module-project-alt/child/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.github.pmckeown.dtmp.tests</groupId>
+        <artifactId>simple-module-project-alt</artifactId>
+        <version>1.0.0-@it.snapshot.timestamp@</version>
+    </parent>
+    <artifactId>modules-project-child-alt</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.github.pmckeown</groupId>
+            <artifactId>dependency-track-maven-plugin</artifactId>
+            <version>${dependency-track-maven-plugin.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.github.pmckeown</groupId>
+                <artifactId>dependency-track-maven-plugin</artifactId>
+                <configuration>
+                    <parentVersion>${project.parent.version}</parentVersion>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+

--- a/src/it/simple-module-project-alt/pom.xml
+++ b/src/it/simple-module-project-alt/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.github.pmckeown.dtmp.tests</groupId>
+    <artifactId>simple-module-project-alt</artifactId>
+    <version>1.0.0-@it.snapshot.timestamp@</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <dependency-track-maven-plugin.version>@project.version@</dependency-track-maven-plugin.version>
+    </properties>
+
+    <modules>
+        <module>child</module>
+    </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+                <version>@cyclonedx-maven-plugin.version@</version>
+                <configuration>
+                    <schemaVersion>1.4</schemaVersion>
+                    <includeBomSerialNumber>true</includeBomSerialNumber>
+                    <includeCompileScope>true</includeCompileScope>
+                    <includeProvidedScope>true</includeProvidedScope>
+                    <includeRuntimeScope>true</includeRuntimeScope>
+                    <includeSystemScope>true</includeSystemScope>
+                    <includeTestScope>false</includeTestScope>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>generate-bom</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>makeBom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.github.pmckeown</groupId>
+                <artifactId>dependency-track-maven-plugin</artifactId>
+                <version>${dependency-track-maven-plugin.version}</version>
+                <inherited>true</inherited>
+                <configuration>
+                    <dependencyTrackBaseUrl>${env.DEPENDENCY_TRACK_BASE_URL}</dependencyTrackBaseUrl>
+                    <apiKey>${env.DEPENDENCY_TRACK_API_KEY}</apiKey>
+                    <failOnError>true</failOnError>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>upload-bom</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>upload-bom</goal>
+                        </goals>
+                        <configuration>
+                            <updateProjectInfo>true</updateProjectInfo>
+                            <isLatest>true</isLatest>
+                            <projectTags>
+                                <name>dog-food</name>
+                            </projectTags>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+

--- a/src/it/simple-module-project/README.md
+++ b/src/it/simple-module-project/README.md
@@ -1,0 +1,7 @@
+This is a maven project with sub-modules. The submodule refers to the project's main project.
+
+The main maven project configures the dependency track plugin to be executed.
+As the submodule uses the main project as parent the child also executes the dependency track plugin.
+
+The project has a ever changing version so that it will always try to upload a new
+version to Dependency Track.

--- a/src/it/simple-module-project/child/pom.xml
+++ b/src/it/simple-module-project/child/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.github.pmckeown.dtmp.tests</groupId>
+        <artifactId>simple-module-project</artifactId>
+        <version>1.0.0-@it.snapshot.timestamp@</version>
+    </parent>
+    <artifactId>modules-project-child</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.github.pmckeown</groupId>
+            <artifactId>dependency-track-maven-plugin</artifactId>
+            <version>${dependency-track-maven-plugin.version}</version>
+        </dependency>
+    </dependencies>
+</project>
+

--- a/src/it/simple-module-project/pom.xml
+++ b/src/it/simple-module-project/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.github.pmckeown.dtmp.tests</groupId>
+    <artifactId>simple-module-project</artifactId>
+    <version>1.0.0-@it.snapshot.timestamp@</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <dependency-track-maven-plugin.version>@project.version@</dependency-track-maven-plugin.version>
+    </properties>
+
+    <modules>
+        <module>child</module>
+    </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+                <version>@cyclonedx-maven-plugin.version@</version>
+                <configuration>
+                    <schemaVersion>1.4</schemaVersion>
+                    <includeBomSerialNumber>true</includeBomSerialNumber>
+                    <includeCompileScope>true</includeCompileScope>
+                    <includeProvidedScope>true</includeProvidedScope>
+                    <includeRuntimeScope>true</includeRuntimeScope>
+                    <includeSystemScope>true</includeSystemScope>
+                    <includeTestScope>false</includeTestScope>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>generate-bom</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>makeBom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.github.pmckeown</groupId>
+                <artifactId>dependency-track-maven-plugin</artifactId>
+                <version>${dependency-track-maven-plugin.version}</version>
+                <configuration>
+                    <dependencyTrackBaseUrl>${env.DEPENDENCY_TRACK_BASE_URL}</dependencyTrackBaseUrl>
+                    <apiKey>${env.DEPENDENCY_TRACK_API_KEY}</apiKey>
+                    <failOnError>true</failOnError>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>upload-bom</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>upload-bom</goal>
+                        </goals>
+                        <configuration>
+                            <updateProjectInfo>true</updateProjectInfo>
+                            <isLatest>true</isLatest>
+                            <projectTags>
+                                <name>dog-food</name>
+                            </projectTags>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+

--- a/src/main/java/io/github/pmckeown/dependencytrack/ModuleConfig.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/ModuleConfig.java
@@ -24,7 +24,7 @@ public class ModuleConfig {
     private MavenProject mavenProject;
     private boolean updateProjectInfo;
     private boolean updateParent;
-    private boolean isLatest;
+    private Boolean isLatest;
     private boolean autoCreate = true;
     private Set<String> projectTags = Collections.emptySet();
 
@@ -128,11 +128,11 @@ public class ModuleConfig {
         this.updateProjectInfo = updateProjectInfo;
     }
 
-    public boolean isLatest() {
+    public Boolean isLatest() {
         return isLatest;
     }
 
-    public void setLatest(boolean latest) {
+    public void setLatest(Boolean latest) {
         isLatest = latest;
     }
 

--- a/src/main/java/io/github/pmckeown/dependencytrack/project/Project.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/project/Project.java
@@ -19,7 +19,7 @@ public class Project extends Item {
     private String name;
     private String version;
     private Metrics metrics;
-    private boolean isLatest;
+    private Boolean isLatest;
     private List<ProjectTag> tags;
 
     @JsonCreator
@@ -27,7 +27,7 @@ public class Project extends Item {
                    @JsonProperty("name") String name,
                    @JsonProperty("version") String version,
                    @JsonProperty("metrics") Metrics metrics,
-                   @JsonProperty("isLatest") boolean isLatest,
+                   @JsonProperty("isLatest") Boolean isLatest,
                    @JsonProperty("tags") List<ProjectTag> tags) {
         super(uuid);
         this.name = name;
@@ -49,7 +49,7 @@ public class Project extends Item {
         return metrics;
     }
 
-    public boolean isLatest() {
+    public Boolean isLatest() {
         return isLatest;
     }
 

--- a/src/main/java/io/github/pmckeown/dependencytrack/project/ProjectAction.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/project/ProjectAction.java
@@ -85,7 +85,7 @@ public class ProjectAction {
             Optional<ProjectInfo> optInfo = bomParser.getProjectInfo(new File(updateReq.getBomLocation()));
             if (optInfo.isPresent()) {
                 info = optInfo.get();
-                info.setIsLatest(Boolean.valueOf(project.isLatest()));
+                info.setIsLatest(project.isLatest());
             } else {
                 logger.warn("Could not create ProjectInfo from bom at location: %s", updateReq.getBomLocation());
                 return false;

--- a/src/main/java/io/github/pmckeown/dependencytrack/upload/BomClient.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/upload/BomClient.java
@@ -2,6 +2,7 @@ package io.github.pmckeown.dependencytrack.upload;
 
 import io.github.pmckeown.dependencytrack.CommonConfig;
 import io.github.pmckeown.dependencytrack.Response;
+import io.github.pmckeown.util.Logger;
 import kong.unirest.GenericType;
 import kong.unirest.HttpResponse;
 import kong.unirest.RequestBodyEntity;
@@ -25,10 +26,12 @@ import static kong.unirest.Unirest.get;
 class BomClient {
 
     private CommonConfig commonConfig;
+    private Logger logger;
 
     @Inject
-    BomClient(CommonConfig commonConfig) {
+    BomClient(CommonConfig commonConfig, Logger logger) {
         this.commonConfig = commonConfig;
+        this.logger = logger;
     }
 
     /**
@@ -51,6 +54,9 @@ class BomClient {
         if (httpResponse.isSuccess()) {
             body = Optional.of(httpResponse.getBody());
         } else {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Server response body: %s", httpResponse.mapError(String.class));
+            }
             body = Optional.empty();
         }
 

--- a/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomAction.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomAction.java
@@ -38,7 +38,7 @@ public class UploadBomAction {
     public boolean upload(ModuleConfig moduleConfig) throws DependencyTrackException {
         logger.info("Project Name: %s", moduleConfig.getProjectName());
         logger.info("Project Version: %s", moduleConfig.getProjectVersion());
-        logger.info("Project is latest: %s", moduleConfig.isLatest());
+        logger.info("Project is latest: %s", Boolean.TRUE.equals(moduleConfig.isLatest()));
         logger.info("Project Tags: %s", StringUtils.join(moduleConfig.getProjectTags(), ","));
         logger.info("Parent UUID: %s", moduleConfig.getParentUuid());
         logger.info("Parent Name: %s", moduleConfig.getParentName());

--- a/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojo.java
@@ -58,8 +58,8 @@ public class UploadBomMojo extends AbstractDependencyTrackMojo {
     @Parameter(property = "dependency-track.parentVersion")
     private String parentVersion;
 
-    @Parameter(property = "dependency-track.isLatest", defaultValue = "false")
-    private boolean isLatest;
+    @Parameter(property = "dependency-track.isLatest")
+    private Boolean isLatest;
 
     @Parameter(property = "dependency-track.projectTags")
     private Set<String> projectTags;

--- a/src/main/java/io/github/pmckeown/util/Logger.java
+++ b/src/main/java/io/github/pmckeown/util/Logger.java
@@ -54,6 +54,10 @@ public class Logger {
         }
     }
 
+    public boolean isDebugEnabled() {
+        return log != null && log.isDebugEnabled();
+    }
+
     public void error(String template, Object... params) {
         assertLogSupplied();
         if(log.isErrorEnabled()) {

--- a/src/test/java/io/github/pmckeown/dependencytrack/ModuleConfigTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/ModuleConfigTest.java
@@ -13,7 +13,6 @@ import java.io.File;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doReturn;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/src/test/java/io/github/pmckeown/dependencytrack/ModuleConfigTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/ModuleConfigTest.java
@@ -13,14 +13,11 @@ import java.io.File;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doReturn;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ModuleConfigTest {
-
-    private static final String PROJECT_NAME = "test";
-
-    private static final String PROJECT_VERSION = "1.0";
 
     @Mock
     private MavenProject project;
@@ -39,6 +36,5 @@ public class ModuleConfigTest {
         doReturn(new File(".")).when(project).getBasedir();
 
         assertThat(moduleConfig.getBomLocation(), is(equalTo("./target/bom.xml")));
-        assertThat(moduleConfig.isLatest(), is(equalTo(false)));
     }
 }

--- a/src/test/java/io/github/pmckeown/dependencytrack/upload/BomClientIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/upload/BomClientIntegrationTest.java
@@ -4,9 +4,13 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.http.Fault;
 import io.github.pmckeown.dependencytrack.AbstractDependencyTrackIntegrationTest;
 import io.github.pmckeown.dependencytrack.Response;
+import io.github.pmckeown.util.Logger;
 import kong.unirest.UnirestException;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static io.github.pmckeown.dependencytrack.ResourceConstants.V1_BOM;
@@ -19,15 +23,19 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
+@RunWith(MockitoJUnitRunner.class)
 public class BomClientIntegrationTest extends AbstractDependencyTrackIntegrationTest {
 
     private static final String BASE_64_ENCODED_BOM = "blah";
+
+    @Mock
+    private Logger logger;
 
     private BomClient client;
 
     @Before
     public void setup() {
-        client = new BomClient(getCommonConfig());
+        client = new BomClient(getCommonConfig(), logger);
     }
 
     @Test


### PR DESCRIPTION
* Test projects to validate parent project handling during BOM upload

These test projects show different maven project configurations which deal with parent projects.

* Only set parentName or parentVersion when both are set

For new project versions both values are required in order to resolve the parent. The parentName defaults to ${project.parent.name}, but parentVersion defaults to null. This combination would result in a 404 response from Dependency Track when uploading a new (child) project version.

As parentName is also always set it also prevents a project from not being registered as a child project. Unsetting the default value is not possible from the pom.xml, only via a system property.

See issue #441

* Moved cyclonedx-maven-plugin version to a property

* Made isLatest and projectTags optional

This enables compatibility with Server 4.8.0 and later (I did not test older servers). This also fixes issue #438

Updated the documentation to include plugin/server compatibility.

* Corrected test cases

Broke some unit tests, and an integration test artifactId was incorrect.

* Testing documentation update

---------