### PR TITLE
Fix last occurrence metrics printing

### DIFF
--- a/src/main/java/io/github/pmckeown/dependencytrack/metrics/MetricsPrinter.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/metrics/MetricsPrinter.java
@@ -57,7 +57,7 @@ class MetricsPrinter {
         logger.info(formatForPrinting(FINDINGS_AUDITED, metrics.getFindingsAudited()));
         logger.info(formatForPrinting(FINDINGS_UNAUDITED, metrics.getFindingsUnaudited()));
         logger.info(formatForPrinting(FIRST_OCCURRENCE, formatDate(metrics.getFirstOccurrence())));
-        logger.info(formatForPrinting(LAST_OCCURRENCE, formatDate(metrics.getFirstOccurrence())));
+        logger.info(formatForPrinting(LAST_OCCURRENCE, formatDate(metrics.getLastOccurrence())));
         logger.info(DELIMITER);
     }
 


### PR DESCRIPTION
## Summary
- fix bug in MetricsPrinter to display last occurrence date

## Testing
- `mvn -q test` *(fails: `mvn` not found)*