### PR TITLE
Added spotless plugin to enforce codestyle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.github.pmckeown</groupId>
@@ -11,8 +9,8 @@
     <packaging>maven-plugin</packaging>
 
     <name>Dependency Track Maven Plugin</name>
-    <url>https://github.com/pmckeown/dependency-track-maven-plugin</url>
     <description>Maven plugin to integrate with a Dependency Track server to submit dependency manifests and gather project metrics. Can be used within build pipelines to analyse the current project and optionally fail the build if vulnerabilities are found.</description>
+    <url>https://github.com/pmckeown/dependency-track-maven-plugin</url>
     <inceptionYear>2019</inceptionYear>
 
     <licenses>
@@ -34,9 +32,9 @@
 
     <scm>
         <connection>scm:git:git@github.com:pmckeown/dependency-track-maven-plugin.git</connection>
-        <url>https://github.com/pmckeown/dependency-track-maven-plugin.git</url>
         <developerConnection>scm:git:git@github.com:pmckeown/dependency-track-maven-plugin.git</developerConnection>
         <tag>HEAD</tag>
+        <url>https://github.com/pmckeown/dependency-track-maven-plugin.git</url>
     </scm>
 
     <issueManagement>
@@ -50,19 +48,23 @@
     </ciManagement>
 
     <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
         <repository>
             <id>ossrh</id>
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
     </distributionManagement>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!-- Compile target -->
+        <java.version>8</java.version>
         <maven.version>3.9.5</maven.version>
+        <!-- Version required to build the project -->
+        <java.build.version>11</java.build.version>
         <sonar.organization>pmckeown</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <cyclonedx-maven-plugin.version>2.7.10</cyclonedx-maven-plugin.version>
@@ -220,9 +222,9 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.13.0</version>
                     <configuration>
-                        <release>8</release>
-                        <source>8</source>
-                        <target>8</target>
+                        <release>${java.version}</release>
+                        <source>${java.version}</source>
+                        <target>${java.version}</target>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -278,6 +280,29 @@
 
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.6.1</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>${maven.version}</version>
+                                </requireMavenVersion>
+                                <requireJavaVersion>
+                                    <version>${java.build.version}</version>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <executions>
@@ -295,10 +320,10 @@
                     </execution>
                     <execution>
                         <id>jacoco-site</id>
-                        <phase>verify</phase>
                         <goals>
                             <goal>report</goal>
                         </goals>
+                        <phase>verify</phase>
                     </execution>
                 </executions>
             </plugin>
@@ -307,10 +332,10 @@
                 <executions>
                     <execution>
                         <id>copy-resources</id>
-                        <phase>validate</phase>
                         <goals>
                             <goal>copy-resources</goal>
                         </goals>
+                        <phase>validate</phase>
                         <configuration>
                             <outputDirectory>${basedir}/target/classes/META-INF</outputDirectory>
                             <resources>
@@ -320,6 +345,35 @@
                                 </resource>
                             </resources>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>2.45.0</version>
+                <configuration>
+                    <java>
+                        <palantirJavaFormat/>
+                        <removeUnusedImports/>
+                    </java>
+                    <pom>
+                        <includes>
+                            <include>pom.xml</include>
+                            <include>src/it/*/pom.xml</include>
+                        </includes>
+                        <sortPom>
+                            <nrOfIndentSpace>4</nrOfIndentSpace>
+                            <indentAttribute>schemaLocation</indentAttribute>
+                        </sortPom>
+                    </pom>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <phase>verify</phase>
                     </execution>
                 </executions>
             </plugin>
@@ -380,10 +434,10 @@
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
-                                <phase>verify</phase>
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
+                                <phase>verify</phase>
                             </execution>
                         </executions>
                     </plugin>
@@ -404,10 +458,10 @@
                         <executions>
                             <execution>
                                 <id>generate-index</id>
-                                <phase>package</phase>
                                 <goals>
                                     <goal>index</goal>
                                 </goals>
+                                <phase>package</phase>
                             </execution>
                         </executions>
                     </plugin>
@@ -439,10 +493,10 @@
                         <artifactId>sonar-maven-plugin</artifactId>
                         <executions>
                             <execution>
-                                <phase>verify</phase>
                                 <goals>
                                     <goal>sonar</goal>
                                 </goals>
+                                <phase>verify</phase>
                             </execution>
                         </executions>
                     </plugin>
@@ -481,10 +535,10 @@
                         <executions>
                             <execution>
                                 <id>generate-bom</id>
-                                <phase>verify</phase>
                                 <goals>
                                     <goal>makeAggregateBom</goal>
                                 </goals>
+                                <phase>verify</phase>
                             </execution>
                         </executions>
                     </plugin>
@@ -502,10 +556,10 @@
                         <executions>
                             <execution>
                                 <id>upload-bom</id>
-                                <phase>verify</phase>
                                 <goals>
                                     <goal>upload-bom</goal>
                                 </goals>
+                                <phase>verify</phase>
                                 <configuration>
                                     <updateProjectInfo>true</updateProjectInfo>
                                     <isLatest>true</isLatest>
@@ -516,10 +570,10 @@
                             </execution>
                             <execution>
                                 <id>fail-if-vulnerabilities-present</id>
-                                <phase>verify</phase>
                                 <goals>
                                     <goal>findings</goal>
                                 </goals>
+                                <phase>verify</phase>
                                 <configuration>
                                     <findingThresholds>
                                         <critical>0</critical>
@@ -537,10 +591,10 @@
                         <version>3.6.0</version>
                         <executions>
                             <execution>
-                                <phase>validate</phase>
                                 <goals>
                                     <goal>timestamp-property</goal>
                                 </goals>
+                                <phase>validate</phase>
                                 <configuration>
                                     <pattern>yyyyMMddHHmmss</pattern>
                                     <name>it.snapshot.timestamp</name>

--- a/src/it/common-parent-project/pom.xml
+++ b/src/it/common-parent-project/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.pmckeown.dtmp.tests</groupId>
     <artifactId>common-parent-project</artifactId>
@@ -13,60 +13,59 @@
 
     <build>
         <pluginManagement>
-          <plugins>
-              <plugin>
-                  <groupId>org.cyclonedx</groupId>
-                  <artifactId>cyclonedx-maven-plugin</artifactId>
-                  <version>@cyclonedx-maven-plugin.version@</version>
-                  <inherited>true</inherited>
-                  <configuration>
-                      <schemaVersion>1.4</schemaVersion>
-                      <includeBomSerialNumber>true</includeBomSerialNumber>
-                      <includeCompileScope>true</includeCompileScope>
-                      <includeProvidedScope>true</includeProvidedScope>
-                      <includeRuntimeScope>true</includeRuntimeScope>
-                      <includeSystemScope>true</includeSystemScope>
-                      <includeTestScope>false</includeTestScope>
-                  </configuration>
-                  <executions>
-                      <execution>
-                          <id>generate-bom</id>
-                          <phase>verify</phase>
-                          <goals>
-                              <goal>makeBom</goal>
-                          </goals>
-                      </execution>
-                  </executions>
-              </plugin>
-              <plugin>
-                  <groupId>io.github.pmckeown</groupId>
-                  <artifactId>dependency-track-maven-plugin</artifactId>
-                  <version>${dependency-track-maven-plugin.version}</version>
-                  <inherited>true</inherited>
-                  <configuration>
-                      <dependencyTrackBaseUrl>${env.DEPENDENCY_TRACK_BASE_URL}</dependencyTrackBaseUrl>
-                      <apiKey>${env.DEPENDENCY_TRACK_API_KEY}</apiKey>
-                      <failOnError>true</failOnError>
-                  </configuration>
-                  <executions>
-                      <execution>
-                          <id>upload-bom</id>
-                          <phase>verify</phase>
-                          <goals>
-                              <goal>upload-bom</goal>
-                          </goals>
-                          <configuration>
-                              <updateProjectInfo>true</updateProjectInfo>
-                              <isLatest>true</isLatest>
-                              <projectTags>
-                                  <name>dog-food</name>
-                              </projectTags>
-                          </configuration>
-                      </execution>
-                  </executions>
-              </plugin>
-          </plugins>
+            <plugins>
+                <plugin>
+                    <groupId>org.cyclonedx</groupId>
+                    <artifactId>cyclonedx-maven-plugin</artifactId>
+                    <version>@cyclonedx-maven-plugin.version@</version>
+                    <inherited>true</inherited>
+                    <configuration>
+                        <schemaVersion>1.4</schemaVersion>
+                        <includeBomSerialNumber>true</includeBomSerialNumber>
+                        <includeCompileScope>true</includeCompileScope>
+                        <includeProvidedScope>true</includeProvidedScope>
+                        <includeRuntimeScope>true</includeRuntimeScope>
+                        <includeSystemScope>true</includeSystemScope>
+                        <includeTestScope>false</includeTestScope>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>generate-bom</id>
+                            <goals>
+                                <goal>makeBom</goal>
+                            </goals>
+                            <phase>verify</phase>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>io.github.pmckeown</groupId>
+                    <artifactId>dependency-track-maven-plugin</artifactId>
+                    <version>${dependency-track-maven-plugin.version}</version>
+                    <inherited>true</inherited>
+                    <configuration>
+                        <dependencyTrackBaseUrl>${env.DEPENDENCY_TRACK_BASE_URL}</dependencyTrackBaseUrl>
+                        <apiKey>${env.DEPENDENCY_TRACK_API_KEY}</apiKey>
+                        <failOnError>true</failOnError>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>upload-bom</id>
+                            <goals>
+                                <goal>upload-bom</goal>
+                            </goals>
+                            <phase>verify</phase>
+                            <configuration>
+                                <updateProjectInfo>true</updateProjectInfo>
+                                <isLatest>true</isLatest>
+                                <projectTags>
+                                    <name>dog-food</name>
+                                </projectTags>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
         </pluginManagement>
     </build>
 </project>
-

--- a/src/it/project-with-parent/pom.xml
+++ b/src/it/project-with-parent/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.github.pmckeown.dtmp.tests</groupId>
@@ -32,4 +32,3 @@
         </plugins>
     </build>
 </project>
-

--- a/src/it/simple-module-project-alt/pom.xml
+++ b/src/it/simple-module-project-alt/pom.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.pmckeown.dtmp.tests</groupId>
     <artifactId>simple-module-project-alt</artifactId>
     <version>1.0.0-@it.snapshot.timestamp@</version>
     <packaging>pom</packaging>
 
-    <properties>
-        <dependency-track-maven-plugin.version>@project.version@</dependency-track-maven-plugin.version>
-    </properties>
-
     <modules>
         <module>child</module>
     </modules>
+
+    <properties>
+        <dependency-track-maven-plugin.version>@project.version@</dependency-track-maven-plugin.version>
+    </properties>
 
     <build>
         <plugins>
@@ -33,10 +33,10 @@
                 <executions>
                     <execution>
                         <id>generate-bom</id>
-                        <phase>verify</phase>
                         <goals>
                             <goal>makeBom</goal>
                         </goals>
+                        <phase>verify</phase>
                     </execution>
                 </executions>
             </plugin>
@@ -53,10 +53,10 @@
                 <executions>
                     <execution>
                         <id>upload-bom</id>
-                        <phase>verify</phase>
                         <goals>
                             <goal>upload-bom</goal>
                         </goals>
+                        <phase>verify</phase>
                         <configuration>
                             <updateProjectInfo>true</updateProjectInfo>
                             <isLatest>true</isLatest>
@@ -70,4 +70,3 @@
         </plugins>
     </build>
 </project>
-

--- a/src/it/simple-module-project/pom.xml
+++ b/src/it/simple-module-project/pom.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.pmckeown.dtmp.tests</groupId>
     <artifactId>simple-module-project</artifactId>
     <version>1.0.0-@it.snapshot.timestamp@</version>
     <packaging>pom</packaging>
 
-    <properties>
-        <dependency-track-maven-plugin.version>@project.version@</dependency-track-maven-plugin.version>
-    </properties>
-
     <modules>
         <module>child</module>
     </modules>
+
+    <properties>
+        <dependency-track-maven-plugin.version>@project.version@</dependency-track-maven-plugin.version>
+    </properties>
 
     <build>
         <plugins>
@@ -33,10 +33,10 @@
                 <executions>
                     <execution>
                         <id>generate-bom</id>
-                        <phase>verify</phase>
                         <goals>
                             <goal>makeBom</goal>
                         </goals>
+                        <phase>verify</phase>
                     </execution>
                 </executions>
             </plugin>
@@ -52,10 +52,10 @@
                 <executions>
                     <execution>
                         <id>upload-bom</id>
-                        <phase>verify</phase>
                         <goals>
                             <goal>upload-bom</goal>
                         </goals>
+                        <phase>verify</phase>
                         <configuration>
                             <updateProjectInfo>true</updateProjectInfo>
                             <isLatest>true</isLatest>
@@ -69,4 +69,3 @@
         </plugins>
     </build>
 </project>
-

--- a/src/main/java/io/github/pmckeown/dependencytrack/AbstractDependencyTrackMojo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/AbstractDependencyTrackMojo.java
@@ -1,6 +1,11 @@
 package io.github.pmckeown.dependencytrack;
 
+import static io.github.pmckeown.dependencytrack.ObjectMapperFactory.relaxedObjectMapper;
+import static kong.unirest.HeaderNames.ACCEPT;
+import static kong.unirest.HeaderNames.ACCEPT_ENCODING;
+
 import io.github.pmckeown.util.Logger;
+import java.util.concurrent.atomic.AtomicBoolean;
 import kong.unirest.Unirest;
 import kong.unirest.jackson.JacksonObjectMapper;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -10,24 +15,19 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Parameter;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import static io.github.pmckeown.dependencytrack.ObjectMapperFactory.relaxedObjectMapper;
-import static kong.unirest.HeaderNames.ACCEPT;
-import static kong.unirest.HeaderNames.ACCEPT_ENCODING;
-
 /**
  * Base class for Mojos in this project.
- * <p>
- * Provides common configuration options:
+ *
+ * <p>Provides common configuration options:
+ *
  * <ol>
- *     <li>projectName</li>
- *     <li>projectVersion</li>
- *     <li>dependencyTrackBaseUrl</li>
- *     <li>apiKey</li>
- *     <li>failOnError</li>
- *     <li>skip</li>
- *     <li>verifySsl</li>
+ *   <li>projectName
+ *   <li>projectVersion
+ *   <li>dependencyTrackBaseUrl
+ *   <li>apiKey
+ *   <li>failOnError
+ *   <li>skip
+ *   <li>verifySsl
  * </ol>
  *
  * @author Paul McKeown
@@ -52,13 +52,14 @@ public abstract class AbstractDependencyTrackMojo extends AbstractMojo {
     private boolean failOnError;
 
     /**
-     * Set this to 'true' to bypass dependencyTrack plugin
-     * It's not a real boolean as it can have more than 2 values:
+     * Set this to 'true' to bypass dependencyTrack plugin It's not a real boolean as it can have more
+     * than 2 values:
+     *
      * <ul>
-     *     <li><code>true</code>: will skip as usual</li>
-     *     <li><code>releases</code>: will skip if current version of the project is a release</li>
-     *     <li><code>snapshots</code>: will skip if current version of the project is a snapshot</li>
-     *     <li>any other values will be considered as <code>false</code></li>
+     *   <li><code>true</code>: will skip as usual
+     *   <li><code>releases</code>: will skip if current version of the project is a release
+     *   <li><code>snapshots</code>: will skip if current version of the project is a snapshot
+     *   <li>any other values will be considered as <code>false</code>
      * </ul>
      */
     @Parameter(defaultValue = "false", property = "dependency-track.skip", alias = "dependency-track.skip")
@@ -83,10 +84,11 @@ public abstract class AbstractDependencyTrackMojo extends AbstractMojo {
     }
 
     /**
-     * Initialises the {@link Logger} and {@link CommonConfig} instances that were injected by the SISU inversion of
-     * control container (using Guice under the hood) by providing the data provided by the Plexus IOC container.
-     * <p>
-     * Then performs the action defined by the subclass.
+     * Initialises the {@link Logger} and {@link CommonConfig} instances that were injected by the
+     * SISU inversion of control container (using Guice under the hood) by providing the data provided
+     * by the Plexus IOC container.
+     *
+     * <p>Then performs the action defined by the subclass.
      */
     @Override
     public final void execute() throws MojoExecutionException, MojoFailureException {
@@ -113,7 +115,7 @@ public abstract class AbstractDependencyTrackMojo extends AbstractMojo {
      * Template method to be implemented by subclasses.
      *
      * @throws MojoExecutionException when an error is encountered during Mojo execution
-     * @throws MojoFailureException   when the Mojo fails
+     * @throws MojoFailureException when the Mojo fails
      */
     protected abstract void performAction() throws MojoExecutionException, MojoFailureException;
 
@@ -170,16 +172,16 @@ public abstract class AbstractDependencyTrackMojo extends AbstractMojo {
     }
 
     /**
-     * Unirest is configured globally using a static `Unirest.config()` method.  Doing so here allows for user-supplied
-     * configuration.
+     * Unirest is configured globally using a static `Unirest.config()` method. Doing so here allows
+     * for user-supplied configuration.
      */
     private void configureUnirest() {
-        if(unirestConfiguration.compareAndSet(false, true)) {
+        if (unirestConfiguration.compareAndSet(false, true)) {
             Unirest.config()
-                .setObjectMapper(new JacksonObjectMapper(relaxedObjectMapper()))
-                .setDefaultHeader(ACCEPT_ENCODING, "gzip, deflate")
-                .setDefaultHeader(ACCEPT, "application/json")
-                .verifySsl(verifySsl);
+                    .setObjectMapper(new JacksonObjectMapper(relaxedObjectMapper()))
+                    .setDefaultHeader(ACCEPT_ENCODING, "gzip, deflate")
+                    .setDefaultHeader(ACCEPT, "application/json")
+                    .verifySsl(verifySsl);
 
             // Debug all Unirest config
             logger.debug("Unirest Configuration: %s", ToStringBuilder.reflectionToString(Unirest.config()));
@@ -190,7 +192,8 @@ public abstract class AbstractDependencyTrackMojo extends AbstractMojo {
     }
 
     /**
-     * Provide access to the unirestConfiguration AtomicBoolean to allow tests to reset this config object
+     * Provide access to the unirestConfiguration AtomicBoolean to allow tests to reset this config
+     * object
      *
      * @return unirestConfiguration
      */

--- a/src/main/java/io/github/pmckeown/dependencytrack/CommonConfig.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/CommonConfig.java
@@ -37,5 +37,4 @@ public class CommonConfig {
     public void setPollingConfig(PollingConfig pollingConfig) {
         this.pollingConfig = pollingConfig;
     }
-
 }

--- a/src/main/java/io/github/pmckeown/dependencytrack/DependencyTrackException.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/DependencyTrackException.java
@@ -1,8 +1,6 @@
 package io.github.pmckeown.dependencytrack;
 
-/**
- * Exception class for wrapping exceptions when integrating with Dependency Track
- */
+/** Exception class for wrapping exceptions when integrating with Dependency Track */
 public class DependencyTrackException extends Exception {
 
     public DependencyTrackException(String message) {
@@ -12,5 +10,4 @@ public class DependencyTrackException extends Exception {
     public DependencyTrackException(String message, Throwable cause) {
         super(message, cause);
     }
-
 }

--- a/src/main/java/io/github/pmckeown/dependencytrack/Item.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/Item.java
@@ -5,9 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
-/**
- * Model class so any object that can be referenced by just its UUID
- */
+/** Model class so any object that can be referenced by just its UUID */
 public class Item {
 
     private final String uuid;

--- a/src/main/java/io/github/pmckeown/dependencytrack/ModuleConfig.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/ModuleConfig.java
@@ -1,17 +1,13 @@
 package io.github.pmckeown.dependencytrack;
 
 import io.github.pmckeown.util.Logger;
+import java.util.Collections;
+import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.logging.SystemStreamLog;
 import org.apache.maven.project.MavenProject;
 
-import java.util.Collections;
-import java.util.Set;
-
-/**
- * Holder for module dependent configuration supplied on Mojo execution
- *
- */
+/** Holder for module dependent configuration supplied on Mojo execution */
 public class ModuleConfig {
 
     private String projectUuid = "";
@@ -147,5 +143,4 @@ public class ModuleConfig {
     public void setProjectTags(Set<String> projectTags) {
         this.projectTags = projectTags;
     }
-
 }

--- a/src/main/java/io/github/pmckeown/dependencytrack/ObjectMapperFactory.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/ObjectMapperFactory.java
@@ -16,6 +16,7 @@ public class ObjectMapperFactory {
 
     /**
      * Get an {@link ObjectMapper} instance that is configured to
+     *
      * @return a preconfigured ObjectMapper
      */
     public static ObjectMapper relaxedObjectMapper() {

--- a/src/main/java/io/github/pmckeown/dependencytrack/Poller.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/Poller.java
@@ -4,29 +4,30 @@ import com.evanlennick.retry4j.CallExecutorBuilder;
 import com.evanlennick.retry4j.Status;
 import com.evanlennick.retry4j.config.RetryConfigBuilder;
 import com.evanlennick.retry4j.exception.UnexpectedException;
-
-import javax.inject.Singleton;
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import javax.inject.Singleton;
 
 /**
  * Class for polling a remote server.
  *
- * Polling will continue until the provide callable returns a populated {@link Optional} instance.
+ * <p>Polling will continue until the provide callable returns a populated {@link Optional}
+ * instance.
  *
- * {@link Optional#empty()} will continue the loop until the configured retry limit is me when a
+ * <p>{@link Optional#empty()} will continue the loop until the configured retry limit is me when a
  * {@link com.evanlennick.retry4j.exception.RetriesExhaustedException} will be thrown.
  *
- * Any {@link Exception} encountered will stop the loop and be thrown as an
- * {@link com.evanlennick.retry4j.exception.UnexpectedException}
+ * <p>Any {@link Exception} encountered will stop the loop and be thrown as an {@link
+ * com.evanlennick.retry4j.exception.UnexpectedException}
  *
- * @param <T> The expected return type.  This will be wrapped in an {@link Optional}
+ * @param <T> The expected return type. This will be wrapped in an {@link Optional}
  */
 @Singleton
 public class Poller<T> {
 
     /**
-     * Execute the supplied {@link Callable} until a non-empty Optional value is returned from the Callable.
+     * Execute the supplied {@link Callable} until a non-empty Optional value is returned from the
+     * Callable.
      *
      * @param pollingConfig The polling configuration
      * @param callable The {@link Callable} function to execute one or more times

--- a/src/main/java/io/github/pmckeown/dependencytrack/PollingConfig.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/PollingConfig.java
@@ -1,10 +1,9 @@
 package io.github.pmckeown.dependencytrack;
 
+import java.time.temporal.ChronoUnit;
+import javax.inject.Singleton;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-
-import javax.inject.Singleton;
-import java.time.temporal.ChronoUnit;
 
 @Singleton
 public class PollingConfig {
@@ -65,7 +64,10 @@ public class PollingConfig {
         }
     }
 
-    public enum TimeUnit {SECONDS, MILLIS}
+    public enum TimeUnit {
+        SECONDS,
+        MILLIS
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/io/github/pmckeown/dependencytrack/Response.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/Response.java
@@ -1,9 +1,8 @@
 package io.github.pmckeown.dependencytrack;
 
+import java.util.Optional;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-
-import java.util.Optional;
 
 /**
  * Wrapper for API responses from the Dependency Track server

--- a/src/main/java/io/github/pmckeown/dependencytrack/bom/BomParser.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/bom/BomParser.java
@@ -2,17 +2,15 @@ package io.github.pmckeown.dependencytrack.bom;
 
 import io.github.pmckeown.dependencytrack.project.ProjectInfo;
 import io.github.pmckeown.util.Logger;
+import java.io.File;
+import java.util.Optional;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.BOMInputStream;
-
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.model.Component;
 import org.cyclonedx.parsers.BomParserFactory;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import java.io.File;
-import java.util.Optional;
 
 /**
  * Encodes a BOM file in the Base64 format.
@@ -32,9 +30,9 @@ public class BomParser {
     /**
      * Parses the Project Info from a BOM {@link File}.
      *
-     * Guarantees to return an {@link Optional} containing a {@link ProjectInfo} object if the provided BOM file can
-     * be parsed successfully.
-     * An empty {@link Optional} will be returned if the file be parsed.
+     * <p>Guarantees to return an {@link Optional} containing a {@link ProjectInfo} object if the
+     * provided BOM file can be parsed successfully. An empty {@link Optional} will be returned if the
+     * file be parsed.
      *
      * @param bomFile File containing a BOM
      * @return an optional that will contain the parsed {@link ProjectInfo} or an empty optional
@@ -45,7 +43,8 @@ public class BomParser {
             return Optional.empty();
         }
         Bom bom;
-        try (BOMInputStream bis = BOMInputStream.builder().setFile(bomFile).setInclude(false).get()) {
+        try (BOMInputStream bis =
+                BOMInputStream.builder().setFile(bomFile).setInclude(false).get()) {
             byte[] bytes = IOUtils.toByteArray(bis);
             bom = BomParserFactory.createParser(bytes).parse(bytes);
         } catch (Exception ex) {
@@ -57,7 +56,7 @@ public class BomParser {
             return Optional.empty();
         }
 
-        Component component =  bom.getMetadata().getComponent();
+        Component component = bom.getMetadata().getComponent();
         ProjectInfo info = new ProjectInfo();
         if (component.getType() != null) {
             info.setClassifier(component.getType().name());

--- a/src/main/java/io/github/pmckeown/dependencytrack/finding/Analysis.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/finding/Analysis.java
@@ -2,10 +2,9 @@ package io.github.pmckeown.dependencytrack.finding;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.xml.bind.annotation.XmlElement;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-
-import javax.xml.bind.annotation.XmlElement;
 
 public class Analysis {
 

--- a/src/main/java/io/github/pmckeown/dependencytrack/finding/Component.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/finding/Component.java
@@ -2,10 +2,9 @@ package io.github.pmckeown.dependencytrack.finding;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.xml.bind.annotation.XmlElement;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-
-import javax.xml.bind.annotation.XmlElement;
 
 public class Component {
 
@@ -15,8 +14,11 @@ public class Component {
     private String version;
 
     @JsonCreator
-    public Component(@JsonProperty("uuid") String uuid, @JsonProperty("name") String name,
-             @JsonProperty("group") String group, @JsonProperty("version") String version) {
+    public Component(
+            @JsonProperty("uuid") String uuid,
+            @JsonProperty("name") String name,
+            @JsonProperty("group") String group,
+            @JsonProperty("version") String version) {
         this.uuid = uuid;
         this.name = name;
         this.group = group;

--- a/src/main/java/io/github/pmckeown/dependencytrack/finding/Finding.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/finding/Finding.java
@@ -2,11 +2,10 @@ package io.github.pmckeown.dependencytrack.finding;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
-
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 @XmlType
 public class Finding {
@@ -16,8 +15,10 @@ public class Finding {
     private Analysis analysis;
 
     @JsonCreator
-    public Finding(@JsonProperty("component") Component component,
-           @JsonProperty("vulnerability") Vulnerability vulnerability, @JsonProperty("analysis") Analysis analysis) {
+    public Finding(
+            @JsonProperty("component") Component component,
+            @JsonProperty("vulnerability") Vulnerability vulnerability,
+            @JsonProperty("analysis") Analysis analysis) {
         this.component = component;
         this.vulnerability = vulnerability;
         this.analysis = analysis;

--- a/src/main/java/io/github/pmckeown/dependencytrack/finding/FindingsAction.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/finding/FindingsAction.java
@@ -4,13 +4,12 @@ import io.github.pmckeown.dependencytrack.DependencyTrackException;
 import io.github.pmckeown.dependencytrack.Response;
 import io.github.pmckeown.dependencytrack.project.Project;
 import io.github.pmckeown.util.Logger;
-import kong.unirest.UnirestException;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import kong.unirest.UnirestException;
 
 @Singleton
 public class FindingsAction {
@@ -35,8 +34,7 @@ public class FindingsAction {
                 if (body.isPresent()) {
                     return body.get();
                 } else {
-                    logger.info("No findings available for project %s-%s", project.getName(),
-                            project.getVersion());
+                    logger.info("No findings available for project %s-%s", project.getName(), project.getVersion());
                     return Collections.emptyList();
                 }
             } else {

--- a/src/main/java/io/github/pmckeown/dependencytrack/finding/FindingsAnalyser.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/finding/FindingsAnalyser.java
@@ -1,17 +1,16 @@
 package io.github.pmckeown.dependencytrack.finding;
 
-import io.github.pmckeown.dependencytrack.Constants;
-import io.github.pmckeown.util.Logger;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import java.util.List;
-
 import static io.github.pmckeown.dependencytrack.finding.Severity.CRITICAL;
 import static io.github.pmckeown.dependencytrack.finding.Severity.HIGH;
-import static io.github.pmckeown.dependencytrack.finding.Severity.MEDIUM;
 import static io.github.pmckeown.dependencytrack.finding.Severity.LOW;
+import static io.github.pmckeown.dependencytrack.finding.Severity.MEDIUM;
 import static io.github.pmckeown.dependencytrack.finding.Severity.UNASSIGNED;
+
+import io.github.pmckeown.dependencytrack.Constants;
+import io.github.pmckeown.util.Logger;
+import java.util.List;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 
 @Singleton
 public class FindingsAnalyser {
@@ -68,7 +67,9 @@ public class FindingsAnalyser {
     }
 
     private long getCount(List<Finding> findings, Severity severity) {
-        return findings.stream().filter(f -> f.getVulnerability().getSeverity() == severity
-                && !f.getAnalysis().isSuppressed()).count();
+        return findings.stream()
+                .filter(f -> f.getVulnerability().getSeverity() == severity
+                        && !f.getAnalysis().isSuppressed())
+                .count();
     }
 }

--- a/src/main/java/io/github/pmckeown/dependencytrack/finding/FindingsClient.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/finding/FindingsClient.java
@@ -1,19 +1,18 @@
 package io.github.pmckeown.dependencytrack.finding;
 
+import static io.github.pmckeown.dependencytrack.ResourceConstants.V1_FINDING_PROJECT_UUID;
+import static kong.unirest.Unirest.get;
+
 import io.github.pmckeown.dependencytrack.CommonConfig;
 import io.github.pmckeown.dependencytrack.Response;
 import io.github.pmckeown.dependencytrack.project.Project;
 import io.github.pmckeown.util.Logger;
-import kong.unirest.GenericType;
-import kong.unirest.HttpResponse;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import java.util.List;
 import java.util.Optional;
-
-import static io.github.pmckeown.dependencytrack.ResourceConstants.V1_FINDING_PROJECT_UUID;
-import static kong.unirest.Unirest.get;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import kong.unirest.GenericType;
+import kong.unirest.HttpResponse;
 
 @Singleton
 class FindingsClient {
@@ -28,14 +27,13 @@ class FindingsClient {
         this.logger = logger;
     }
 
-
     Response<List<Finding>> getFindingsForProject(Project project) {
         logger.debug("Getting findings for project: %s-%s", project.getName(), project.getVersion());
-        final HttpResponse<List<Finding>> httpResponse = get(
-                commonConfig.getDependencyTrackBaseUrl() + V1_FINDING_PROJECT_UUID)
+        final HttpResponse<List<Finding>> httpResponse = get(commonConfig.getDependencyTrackBaseUrl()
+                        + V1_FINDING_PROJECT_UUID)
                 .header("X-Api-Key", commonConfig.getApiKey())
                 .routeParam("uuid", project.getUuid())
-                .asObject(new GenericType<List<Finding>>(){});
+                .asObject(new GenericType<List<Finding>>() {});
 
         Optional<List<Finding>> body;
         if (httpResponse.isSuccess()) {
@@ -44,7 +42,6 @@ class FindingsClient {
             body = Optional.empty();
         }
 
-        return new Response<>(httpResponse.getStatus(), httpResponse.getStatusText(),
-                httpResponse.isSuccess(), body);
+        return new Response<>(httpResponse.getStatus(), httpResponse.getStatusText(), httpResponse.isSuccess(), body);
     }
 }

--- a/src/main/java/io/github/pmckeown/dependencytrack/finding/FindingsMojo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/finding/FindingsMojo.java
@@ -1,5 +1,7 @@
 package io.github.pmckeown.dependencytrack.finding;
 
+import static org.apache.maven.plugins.annotations.LifecyclePhase.VERIFY;
+
 import io.github.pmckeown.dependencytrack.AbstractDependencyTrackMojo;
 import io.github.pmckeown.dependencytrack.CommonConfig;
 import io.github.pmckeown.dependencytrack.DependencyTrackException;
@@ -8,29 +10,28 @@ import io.github.pmckeown.dependencytrack.finding.report.FindingsReportGenerator
 import io.github.pmckeown.dependencytrack.project.Project;
 import io.github.pmckeown.dependencytrack.project.ProjectAction;
 import io.github.pmckeown.util.Logger;
+import java.io.File;
+import java.util.List;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import java.io.File;
-import java.util.List;
-
-import static org.apache.maven.plugins.annotations.LifecyclePhase.VERIFY;
-
 /**
- * Print the findings retrieved from the Dependency Track Server after a BOM upload.  This is calculated immediately
- * by the server and as such can be used in situations where you want to know if a change to your application pom.xml
- * has had an impact on the vulnerabilities present in your application.
- * <p>
- * You can optionally define thresholds for failing the build where the number of issues in a particular category
- * is greater than the threshold you define for that category.
- * <p>
- * For example the following configuration with fail the build if there are any Critical or High issues found in the
- * scan, more than 10 medium issues or more than 20 low issues.
+ * Print the findings retrieved from the Dependency Track Server after a BOM upload. This is
+ * calculated immediately by the server and as such can be used in situations where you want to know
+ * if a change to your application pom.xml has had an impact on the vulnerabilities present in your
+ * application.
+ *
+ * <p>You can optionally define thresholds for failing the build where the number of issues in a
+ * particular category is greater than the threshold you define for that category.
+ *
+ * <p>For example the following configuration with fail the build if there are any Critical or High
+ * issues found in the scan, more than 10 medium issues or more than 20 low issues.
+ *
  * <pre>
  * &lt;findingThresholds&gt;
  *     &lt;critical&gt;0&lt;/critical&gt;
@@ -40,20 +41,21 @@ import static org.apache.maven.plugins.annotations.LifecyclePhase.VERIFY;
  *     &lt;unassigned&gt;30&lt;/unassigned&gt;
  * &lt;/findingThresholds&gt;
  * </pre>
+ *
  * This allows you to tune build failures to your risk appetite.
- * <p>
- * Specific configuration options are:
+ *
+ * <p>Specific configuration options are:
+ *
  * <ol>
- *     <li>findingThresholds</li>
- *     <li>
- *          <ol>
- *              <li>critical</li>
- *              <li>high</li>
- *              <li>medium</li>
- *              <li>low</li>
- *              <li>unassigned</li>
- *          </ol>
- *     </li>
+ *   <li>findingThresholds
+ *   <li>
+ *       <ol>
+ *         <li>critical
+ *         <li>high
+ *         <li>medium
+ *         <li>low
+ *         <li>unassigned
+ *       </ol>
  * </ol>
  *
  * @author Paul McKeown
@@ -90,9 +92,15 @@ public class FindingsMojo extends AbstractDependencyTrackMojo {
     private FindingsReportGenerator findingsReportGenerator;
 
     @Inject
-    public FindingsMojo(ProjectAction projectAction, FindingsAction findingsAction, FindingsPrinter findingsPrinter,
-                        FindingsAnalyser findingsAnalyser, FindingsReportGenerator findingsReportGenerator,
-                        CommonConfig commonConfig, ModuleConfig moduleConfig, Logger logger) {
+    public FindingsMojo(
+            ProjectAction projectAction,
+            FindingsAction findingsAction,
+            FindingsPrinter findingsPrinter,
+            FindingsAnalyser findingsAnalyser,
+            FindingsReportGenerator findingsReportGenerator,
+            CommonConfig commonConfig,
+            ModuleConfig moduleConfig,
+            Logger logger) {
         super(commonConfig, moduleConfig, logger);
         this.projectAction = projectAction;
         this.findingsAction = findingsAction;
@@ -122,15 +130,23 @@ public class FindingsMojo extends AbstractDependencyTrackMojo {
     }
 
     /**
-     * If Maven options are provided on the command line and the {@link FindingThresholds} is not already populated
-     * from XML configuration, populate the {@link FindingThresholds} from those options.
+     * If Maven options are provided on the command line and the {@link FindingThresholds} is not
+     * already populated from XML configuration, populate the {@link FindingThresholds} from those
+     * options.
      */
     void populateThresholdFromCliOptions() {
-        if (this.findingThresholds == null && (this.thresholdCritical != null || this.thresholdHigh != null ||
-                this.thresholdMedium != null || this.thresholdLow != null || this.thresholdUnassigned != null)) {
+        if (this.findingThresholds == null
+                && (this.thresholdCritical != null
+                        || this.thresholdHigh != null
+                        || this.thresholdMedium != null
+                        || this.thresholdLow != null
+                        || this.thresholdUnassigned != null)) {
             this.findingThresholds = new FindingThresholds(
-                    this.thresholdCritical, this.thresholdHigh, this.thresholdMedium,
-                    this.thresholdLow, this.thresholdUnassigned);
+                    this.thresholdCritical,
+                    this.thresholdHigh,
+                    this.thresholdMedium,
+                    this.thresholdLow,
+                    this.thresholdUnassigned);
         }
     }
 

--- a/src/main/java/io/github/pmckeown/dependencytrack/finding/FindingsPrinter.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/finding/FindingsPrinter.java
@@ -1,18 +1,17 @@
 package io.github.pmckeown.dependencytrack.finding;
 
-import io.github.pmckeown.dependencytrack.project.Project;
-import io.github.pmckeown.util.Logger;
-import org.apache.commons.lang3.StringUtils;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.IntStream;
-
 import static io.github.pmckeown.dependencytrack.Constants.DELIMITER;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.joinWith;
+
+import io.github.pmckeown.dependencytrack.project.Project;
+import io.github.pmckeown.util.Logger;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.IntStream;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.apache.commons.lang3.StringUtils;
 
 @Singleton
 class FindingsPrinter {
@@ -71,5 +70,4 @@ class FindingsPrinter {
         Component component = finding.getComponent();
         return joinWith(":", component.getGroup(), component.getName(), component.getVersion());
     }
-
 }

--- a/src/main/java/io/github/pmckeown/dependencytrack/finding/Severity.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/finding/Severity.java
@@ -1,5 +1,9 @@
 package io.github.pmckeown.dependencytrack.finding;
 
 public enum Severity {
-    CRITICAL, HIGH, MEDIUM, LOW, UNASSIGNED
+    CRITICAL,
+    HIGH,
+    MEDIUM,
+    LOW,
+    UNASSIGNED
 }

--- a/src/main/java/io/github/pmckeown/dependencytrack/finding/Vulnerability.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/finding/Vulnerability.java
@@ -2,10 +2,9 @@ package io.github.pmckeown.dependencytrack.finding;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.xml.bind.annotation.XmlElement;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-
-import javax.xml.bind.annotation.XmlElement;
 
 public class Vulnerability {
 
@@ -16,8 +15,11 @@ public class Vulnerability {
     private String description;
 
     @JsonCreator
-    public Vulnerability(@JsonProperty("uuid") String uuid, @JsonProperty("source") String source,
-             @JsonProperty("vulnId") String vulnId, @JsonProperty("severity") Severity severity,
+    public Vulnerability(
+            @JsonProperty("uuid") String uuid,
+            @JsonProperty("source") String source,
+            @JsonProperty("vulnId") String vulnId,
+            @JsonProperty("severity") Severity severity,
             @JsonProperty("description") String description) {
         this.uuid = uuid;
         this.source = source;

--- a/src/main/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReport.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReport.java
@@ -4,13 +4,12 @@ import io.github.pmckeown.dependencytrack.finding.Finding;
 import io.github.pmckeown.dependencytrack.finding.FindingThresholds;
 import io.github.pmckeown.dependencytrack.finding.Severity;
 import io.github.pmckeown.dependencytrack.report.Report;
-
+import java.util.List;
+import java.util.stream.Collectors;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @XmlRootElement(name = "findingsReport")
 @XmlType(propOrder = {"policyApplied", "policyBreached", "critical", "high", "medium", "low", "unassigned"})
@@ -40,17 +39,17 @@ public class FindingsReport implements Report {
         return policyBreached;
     }
 
-    @XmlElement(name="critical")
+    @XmlElement(name = "critical")
     public FindingsWrapper getCritical() {
         return filterFindings(findings, Severity.CRITICAL);
     }
 
-    @XmlElement(name="high")
+    @XmlElement(name = "high")
     public FindingsWrapper getHigh() {
         return filterFindings(findings, Severity.HIGH);
     }
 
-    @XmlElement(name="medium")
+    @XmlElement(name = "medium")
     public FindingsWrapper getMedium() {
         return filterFindings(findings, Severity.MEDIUM);
     }
@@ -66,12 +65,15 @@ public class FindingsReport implements Report {
     }
 
     private FindingsWrapper filterFindings(List<Finding> findings, Severity severity) {
-        List<Finding> filteredFindings = findings.stream().filter(
-                finding -> finding.getVulnerability().getSeverity() ==  severity).collect(Collectors.toList());
+        List<Finding> filteredFindings = findings.stream()
+                .filter(finding -> finding.getVulnerability().getSeverity() == severity)
+                .collect(Collectors.toList());
         return new FindingsWrapper(filteredFindings.size(), filteredFindings);
     }
 
-    @XmlType(propOrder = { "info", "critical", "high", "medium", "low", "unassigned" }, name = "policyApplied")
+    @XmlType(
+            propOrder = {"info", "critical", "high", "medium", "low", "unassigned"},
+            name = "policyApplied")
     static class PolicyApplied {
 
         private static final String NO_POLICY_APPLIED_MESSAGE = "No policy was applied";

--- a/src/main/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportConstants.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportConstants.java
@@ -13,5 +13,4 @@ class FindingsReportConstants {
     static final String META_INF_DIRECTORY = "/META-INF";
 
     static final String XSL_STYLESHEET_FILENAME = META_INF_DIRECTORY + "/dependency-track-findings-transformer.xsl";
-
 }

--- a/src/main/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportGenerator.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportGenerator.java
@@ -3,11 +3,10 @@ package io.github.pmckeown.dependencytrack.finding.report;
 import io.github.pmckeown.dependencytrack.DependencyTrackException;
 import io.github.pmckeown.dependencytrack.finding.Finding;
 import io.github.pmckeown.dependencytrack.finding.FindingThresholds;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import java.io.File;
 import java.util.List;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 
 @Singleton
 public class FindingsReportGenerator {
@@ -16,14 +15,15 @@ public class FindingsReportGenerator {
     private FindingsReportHtmlReportWriter htmlReportWriter;
 
     @Inject
-    public FindingsReportGenerator(FindingsReportXmlReportWriter xmlReportWriter,
-            FindingsReportHtmlReportWriter htmlReportWriter) {
+    public FindingsReportGenerator(
+            FindingsReportXmlReportWriter xmlReportWriter, FindingsReportHtmlReportWriter htmlReportWriter) {
         this.xmlReportWriter = xmlReportWriter;
         this.htmlReportWriter = htmlReportWriter;
     }
 
-    public void generate(File buildDirectory, List<Finding> findings, FindingThresholds findingThresholds,
-            boolean policyBreached) throws DependencyTrackException {
+    public void generate(
+            File buildDirectory, List<Finding> findings, FindingThresholds findingThresholds, boolean policyBreached)
+            throws DependencyTrackException {
         FindingsReport findingsReport = new FindingsReport(findingThresholds, findings, policyBreached);
         xmlReportWriter.write(buildDirectory, findingsReport);
         htmlReportWriter.write(buildDirectory);

--- a/src/main/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportHtmlReportWriter.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportHtmlReportWriter.java
@@ -2,11 +2,10 @@ package io.github.pmckeown.dependencytrack.finding.report;
 
 import io.github.pmckeown.dependencytrack.report.AbstractHtmlReportWriter;
 import io.github.pmckeown.dependencytrack.report.TransformerFactoryProvider;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import java.io.File;
 import java.io.InputStream;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 
 @Singleton
 public class FindingsReportHtmlReportWriter extends AbstractHtmlReportWriter {
@@ -28,7 +27,7 @@ public class FindingsReportHtmlReportWriter extends AbstractHtmlReportWriter {
 
     @Override
     protected InputStream getStylesheetInputStream() {
-        return FindingsReportHtmlReportWriter.class.getResourceAsStream(FindingsReportConstants.XSL_STYLESHEET_FILENAME);
+        return FindingsReportHtmlReportWriter.class.getResourceAsStream(
+                FindingsReportConstants.XSL_STYLESHEET_FILENAME);
     }
-
 }

--- a/src/main/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportXmlReportWriter.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportXmlReportWriter.java
@@ -1,12 +1,11 @@
 package io.github.pmckeown.dependencytrack.finding.report;
 
 import io.github.pmckeown.dependencytrack.report.AbstractXmlReportWriter;
-
+import java.io.File;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
-import java.io.File;
 
 @Singleton
 public class FindingsReportXmlReportWriter extends AbstractXmlReportWriter {

--- a/src/main/java/io/github/pmckeown/dependencytrack/finding/report/FindingsWrapper.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/finding/report/FindingsWrapper.java
@@ -1,10 +1,9 @@
 package io.github.pmckeown.dependencytrack.finding.report;
 
 import io.github.pmckeown.dependencytrack.finding.Finding;
-
+import java.util.List;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
-import java.util.List;
 
 public class FindingsWrapper {
 

--- a/src/main/java/io/github/pmckeown/dependencytrack/metrics/Metrics.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/metrics/Metrics.java
@@ -2,10 +2,9 @@ package io.github.pmckeown.dependencytrack.metrics;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Date;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-
-import java.util.Date;
 
 /**
  * Model class for the Project Metrics object

--- a/src/main/java/io/github/pmckeown/dependencytrack/metrics/MetricsAction.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/metrics/MetricsAction.java
@@ -1,15 +1,13 @@
 package io.github.pmckeown.dependencytrack.metrics;
 
+import static java.lang.String.format;
 
 import io.github.pmckeown.dependencytrack.*;
 import io.github.pmckeown.dependencytrack.project.Project;
 import io.github.pmckeown.util.Logger;
-
+import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.Optional;
-
-import static java.lang.String.format;
 
 /**
  * Handles the integration to Dependency Track for getting Metrics
@@ -54,8 +52,8 @@ public class MetricsAction {
             logger.debug("Metrics found for project: %s", project.getUuid());
             return body.get();
         } else {
-            throw new DependencyTrackException("No metrics have yet been calculated. Request a metrics analysis " +
-                    "in the Dependency Track UI.");
+            throw new DependencyTrackException(
+                    "No metrics have yet been calculated. Request a metrics analysis " + "in the Dependency Track UI.");
         }
     }
 
@@ -73,5 +71,4 @@ public class MetricsAction {
             logger.error("Failed to refresh metrics with exception: %s", ex.getMessage());
         }
     }
-
 }

--- a/src/main/java/io/github/pmckeown/dependencytrack/metrics/MetricsAnalyser.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/metrics/MetricsAnalyser.java
@@ -1,16 +1,15 @@
 package io.github.pmckeown.dependencytrack.metrics;
 
-import io.github.pmckeown.util.Logger;
-import org.apache.maven.plugin.MojoFailureException;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
-
 import static io.github.pmckeown.dependencytrack.Constants.CRITICAL;
 import static io.github.pmckeown.dependencytrack.Constants.HIGH;
-import static io.github.pmckeown.dependencytrack.Constants.MEDIUM;
 import static io.github.pmckeown.dependencytrack.Constants.LOW;
+import static io.github.pmckeown.dependencytrack.Constants.MEDIUM;
 import static io.github.pmckeown.dependencytrack.Constants.UNASSIGNED;
+
+import io.github.pmckeown.util.Logger;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.apache.maven.plugin.MojoFailureException;
 
 @Singleton
 public class MetricsAnalyser {

--- a/src/main/java/io/github/pmckeown/dependencytrack/metrics/MetricsClient.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/metrics/MetricsClient.java
@@ -1,18 +1,17 @@
 package io.github.pmckeown.dependencytrack.metrics;
 
+import static io.github.pmckeown.dependencytrack.ResourceConstants.V1_METRICS_PROJECT_UUID_CURRENT;
+import static io.github.pmckeown.dependencytrack.ResourceConstants.V1_METRICS_PROJECT_UUID_REFRESH;
+import static kong.unirest.Unirest.get;
+
 import io.github.pmckeown.dependencytrack.CommonConfig;
 import io.github.pmckeown.dependencytrack.Response;
 import io.github.pmckeown.dependencytrack.project.Project;
 import io.github.pmckeown.util.Logger;
+import java.util.Optional;
+import javax.inject.Inject;
 import kong.unirest.GenericType;
 import kong.unirest.HttpResponse;
-
-import javax.inject.Inject;
-import java.util.Optional;
-
-import static io.github.pmckeown.dependencytrack.ResourceConstants.V1_METRICS_PROJECT_UUID_CURRENT;
-import static io.github.pmckeown.dependencytrack.ResourceConstants.V1_METRICS_PROJECT_UUID_REFRESH;
-import static kong.unirest.Unirest.get;
 
 /**
  * Client for getting project Metrics from Dependency Track
@@ -33,11 +32,11 @@ class MetricsClient {
 
     Response<Metrics> getMetrics(Project project) {
         logger.debug("Getting metrics for project: %s-%s", project.getName(), project.getVersion());
-        final HttpResponse<Metrics> httpResponse = get(
-                    commonConfig.getDependencyTrackBaseUrl() + V1_METRICS_PROJECT_UUID_CURRENT)
+        final HttpResponse<Metrics> httpResponse = get(commonConfig.getDependencyTrackBaseUrl()
+                        + V1_METRICS_PROJECT_UUID_CURRENT)
                 .header("X-Api-Key", commonConfig.getApiKey())
                 .routeParam("uuid", project.getUuid())
-                .asObject(new GenericType<Metrics>(){});
+                .asObject(new GenericType<Metrics>() {});
 
         Optional<Metrics> body;
         if (httpResponse.isSuccess()) {
@@ -46,14 +45,13 @@ class MetricsClient {
             body = Optional.empty();
         }
 
-        return new Response<>(httpResponse.getStatus(), httpResponse.getStatusText(),
-                httpResponse.isSuccess(), body);
+        return new Response<>(httpResponse.getStatus(), httpResponse.getStatusText(), httpResponse.isSuccess(), body);
     }
 
     public Response<Void> refreshMetrics(Project project) {
         logger.info("Refreshing Metrics for project: %s-%s", project.getName(), project.getVersion());
-        final HttpResponse<?> httpResponse = get(
-                commonConfig.getDependencyTrackBaseUrl() + V1_METRICS_PROJECT_UUID_REFRESH)
+        final HttpResponse<?> httpResponse = get(commonConfig.getDependencyTrackBaseUrl()
+                        + V1_METRICS_PROJECT_UUID_REFRESH)
                 .header("X-Api-Key", commonConfig.getApiKey())
                 .routeParam("uuid", project.getUuid())
                 .asEmpty();

--- a/src/main/java/io/github/pmckeown/dependencytrack/metrics/MetricsMojo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/metrics/MetricsMojo.java
@@ -7,47 +7,40 @@ import io.github.pmckeown.dependencytrack.ModuleConfig;
 import io.github.pmckeown.dependencytrack.project.Project;
 import io.github.pmckeown.dependencytrack.project.ProjectAction;
 import io.github.pmckeown.util.Logger;
+import javax.inject.Inject;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
-import javax.inject.Inject;
-
 /**
  * Print the full set of metrics about a project as determined by the Dependency Track Server
  *
- * You can optionally define thresholds for failing the build where the number of issues in a particular category
- * is greater than the threshold you define for that category.
+ * <p>You can optionally define thresholds for failing the build where the number of issues in a
+ * particular category is greater than the threshold you define for that category.
  *
- * For example the following configuration with fail the build if there are any Critical or High issues found in the
- * scan, more than 10 medium issues or more than 20 low issues.
+ * <p>For example the following configuration with fail the build if there are any Critical or High
+ * issues found in the scan, more than 10 medium issues or more than 20 low issues.
  *
- *  &lt;configuration&gt;
- *      &lt;metricsThresholds&gt;
- *          &lt;critical&gt;0&lt;/critical&gt;
- *          &lt;high&gt;0&lt;/high&gt;
- *          &lt;medium&gt;10&lt;/medium&gt;
- *          &lt;low&gt;20&lt;/low&gt;
- *          &lt;unassigned&gt;30&lt;/unassigned&gt;
- *      &lt;/metricsThresholds&gt;
- *  &lt;/configuration&gt;
+ * <p>&lt;configuration&gt; &lt;metricsThresholds&gt; &lt;critical&gt;0&lt;/critical&gt;
+ * &lt;high&gt;0&lt;/high&gt; &lt;medium&gt;10&lt;/medium&gt; &lt;low&gt;20&lt;/low&gt;
+ * &lt;unassigned&gt;30&lt;/unassigned&gt; &lt;/metricsThresholds&gt; &lt;/configuration&gt;
  *
- * This allows you to tune build failures to your risk appetite.
+ * <p>This allows you to tune build failures to your risk appetite.
  *
- * Specific configuration options are:
+ * <p>Specific configuration options are:
+ *
  * <ol>
- *     <li>metricsThresholds</li>
- *     <li>
- *          <ol>
- *              <li>critical</li>
- *              <li>high</li>
- *              <li>medium</li>
- *              <li>low</li>
- *              <li>unassigned</li>
- *          </ol>
- *     </li>
+ *   <li>metricsThresholds
+ *   <li>
+ *       <ol>
+ *         <li>critical
+ *         <li>high
+ *         <li>medium
+ *         <li>low
+ *         <li>unassigned
+ *       </ol>
  * </ol>
  *
  * @author Paul McKeown
@@ -64,8 +57,14 @@ public class MetricsMojo extends AbstractDependencyTrackMojo {
     private MetricsThresholds metricsThresholds;
 
     @Inject
-    public MetricsMojo(MetricsAction metricsAction, ProjectAction getProjectAction, MetricsPrinter metricsPrinter,
-                       MetricsAnalyser metricsAnalyser, CommonConfig commonConfig, ModuleConfig moduleConfig, Logger logger) {
+    public MetricsMojo(
+            MetricsAction metricsAction,
+            ProjectAction getProjectAction,
+            MetricsPrinter metricsPrinter,
+            MetricsAnalyser metricsAnalyser,
+            CommonConfig commonConfig,
+            ModuleConfig moduleConfig,
+            Logger logger) {
         super(commonConfig, moduleConfig, logger);
         this.metricsAction = metricsAction;
         this.getProjectAction = getProjectAction;

--- a/src/main/java/io/github/pmckeown/dependencytrack/metrics/MetricsPrinter.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/metrics/MetricsPrinter.java
@@ -1,14 +1,5 @@
 package io.github.pmckeown.dependencytrack.metrics;
 
-import io.github.pmckeown.util.Logger;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Date;
-
 import static io.github.pmckeown.dependencytrack.Constants.COMPONENTS;
 import static io.github.pmckeown.dependencytrack.Constants.CRITICAL;
 import static io.github.pmckeown.dependencytrack.Constants.DELIMITER;
@@ -28,6 +19,14 @@ import static io.github.pmckeown.dependencytrack.Constants.VALUE;
 import static io.github.pmckeown.dependencytrack.Constants.VULNERABILITIES;
 import static io.github.pmckeown.dependencytrack.Constants.VULNERABLE_COMPONENTS;
 import static org.apache.commons.lang3.StringUtils.leftPad;
+
+import io.github.pmckeown.util.Logger;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 
 @Singleton
 class MetricsPrinter {

--- a/src/main/java/io/github/pmckeown/dependencytrack/policyviolation/Policy.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/policyviolation/Policy.java
@@ -2,10 +2,9 @@ package io.github.pmckeown.dependencytrack.policyviolation;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.xml.bind.annotation.XmlElement;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-
-import javax.xml.bind.annotation.XmlElement;
 
 public class Policy {
 

--- a/src/main/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyCondition.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyCondition.java
@@ -2,10 +2,9 @@ package io.github.pmckeown.dependencytrack.policyviolation;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.xml.bind.annotation.XmlElement;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-
-import javax.xml.bind.annotation.XmlElement;
 
 public class PolicyCondition {
 
@@ -15,8 +14,11 @@ public class PolicyCondition {
     private String value;
 
     @JsonCreator
-    public PolicyCondition(@JsonProperty("policy") Policy policy, @JsonProperty("subject") String subject,
-            @JsonProperty("operator") String operator, @JsonProperty("value") String value) {
+    public PolicyCondition(
+            @JsonProperty("policy") Policy policy,
+            @JsonProperty("subject") String subject,
+            @JsonProperty("operator") String operator,
+            @JsonProperty("value") String value) {
         this.policy = policy;
         this.subject = subject;
         this.operator = operator;

--- a/src/main/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolation.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolation.java
@@ -3,11 +3,10 @@ package io.github.pmckeown.dependencytrack.policyviolation;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.github.pmckeown.dependencytrack.finding.Component;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
-
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 @XmlType
 public class PolicyViolation {
@@ -17,7 +16,8 @@ public class PolicyViolation {
     private String type;
 
     @JsonCreator
-    public PolicyViolation(@JsonProperty("component") Component component,
+    public PolicyViolation(
+            @JsonProperty("component") Component component,
             @JsonProperty("analysis") PolicyCondition policyCondition,
             @JsonProperty("type") String type) {
         this.component = component;

--- a/src/main/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsAction.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsAction.java
@@ -4,13 +4,12 @@ import io.github.pmckeown.dependencytrack.DependencyTrackException;
 import io.github.pmckeown.dependencytrack.Response;
 import io.github.pmckeown.dependencytrack.project.Project;
 import io.github.pmckeown.util.Logger;
-import kong.unirest.UnirestException;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import kong.unirest.UnirestException;
 
 @Singleton
 public class PolicyViolationsAction {
@@ -35,8 +34,9 @@ public class PolicyViolationsAction {
                 if (body.isPresent()) {
                     return body.get();
                 } else {
-                    logger.info("No policy violations available for project %s-%s", project.getName(),
-                            project.getVersion());
+                    logger.info(
+                            "No policy violations available for project %s-%s",
+                            project.getName(), project.getVersion());
                     return Collections.emptyList();
                 }
             } else {

--- a/src/main/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsAnalyser.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsAnalyser.java
@@ -1,12 +1,11 @@
 package io.github.pmckeown.dependencytrack.policyviolation;
 
 import io.github.pmckeown.util.Logger;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 
 @Singleton
 public class PolicyViolationsAnalyser {
@@ -27,12 +26,12 @@ public class PolicyViolationsAnalyser {
         List<PolicyViolation> policyWarnings = new ArrayList<>();
         boolean policyBreached = false;
 
-        policyFailures.addAll(policyViolations.stream().filter(p ->
-                p.getPolicyCondition().getPolicy().getViolationState() == ViolationState.FAIL)
+        policyFailures.addAll(policyViolations.stream()
+                .filter(p -> p.getPolicyCondition().getPolicy().getViolationState() == ViolationState.FAIL)
                 .collect(Collectors.toList()));
 
-        policyWarnings.addAll(policyViolations.stream().filter(p ->
-                p.getPolicyCondition().getPolicy().getViolationState() == ViolationState.WARN)
+        policyWarnings.addAll(policyViolations.stream()
+                .filter(p -> p.getPolicyCondition().getPolicy().getViolationState() == ViolationState.WARN)
                 .collect(Collectors.toList()));
 
         if (!policyFailures.isEmpty()) {
@@ -49,8 +48,10 @@ public class PolicyViolationsAnalyser {
     }
 
     private void logPolicyBreach(List<PolicyViolation> policyViolationsBreached) {
-        policyViolationsBreached.forEach(policyViolation ->
-            logger.warn(ERROR_TEMPLATE, policyViolation.getPolicyCondition().getPolicy().getName(),
-                    policyViolation.getComponent().getName(), policyViolation.getComponent().getVersion()));
+        policyViolationsBreached.forEach(policyViolation -> logger.warn(
+                ERROR_TEMPLATE,
+                policyViolation.getPolicyCondition().getPolicy().getName(),
+                policyViolation.getComponent().getName(),
+                policyViolation.getComponent().getVersion()));
     }
 }

--- a/src/main/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsClient.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsClient.java
@@ -1,19 +1,18 @@
 package io.github.pmckeown.dependencytrack.policyviolation;
 
+import static io.github.pmckeown.dependencytrack.ResourceConstants.V1_POLICY_VIOLATION_PROJECT_UUID;
+import static kong.unirest.Unirest.get;
+
 import io.github.pmckeown.dependencytrack.CommonConfig;
 import io.github.pmckeown.dependencytrack.Response;
 import io.github.pmckeown.dependencytrack.project.Project;
 import io.github.pmckeown.util.Logger;
-import kong.unirest.GenericType;
-import kong.unirest.HttpResponse;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import java.util.List;
 import java.util.Optional;
-
-import static io.github.pmckeown.dependencytrack.ResourceConstants.V1_POLICY_VIOLATION_PROJECT_UUID;
-import static kong.unirest.Unirest.get;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import kong.unirest.GenericType;
+import kong.unirest.HttpResponse;
 
 @Singleton
 class PolicyViolationsClient {
@@ -30,11 +29,11 @@ class PolicyViolationsClient {
 
     Response<List<PolicyViolation>> getPolicyViolationsForProject(Project project) {
         logger.debug("Getting policy violations for project: %s-%s", project.getName(), project.getVersion());
-        final HttpResponse<List<PolicyViolation>> httpResponse = get(
-                commonConfig.getDependencyTrackBaseUrl() + V1_POLICY_VIOLATION_PROJECT_UUID)
+        final HttpResponse<List<PolicyViolation>> httpResponse = get(commonConfig.getDependencyTrackBaseUrl()
+                        + V1_POLICY_VIOLATION_PROJECT_UUID)
                 .header("X-Api-Key", commonConfig.getApiKey())
                 .routeParam("uuid", project.getUuid())
-                .asObject(new GenericType<List<PolicyViolation>>(){});
+                .asObject(new GenericType<List<PolicyViolation>>() {});
 
         Optional<List<PolicyViolation>> body;
         if (httpResponse.isSuccess()) {
@@ -43,7 +42,6 @@ class PolicyViolationsClient {
             body = Optional.empty();
         }
 
-        return new Response<>(httpResponse.getStatus(), httpResponse.getStatusText(),
-                httpResponse.isSuccess(), body);
+        return new Response<>(httpResponse.getStatus(), httpResponse.getStatusText(), httpResponse.isSuccess(), body);
     }
 }

--- a/src/main/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsMojo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsMojo.java
@@ -1,5 +1,7 @@
 package io.github.pmckeown.dependencytrack.policyviolation;
 
+import static org.apache.maven.plugins.annotations.LifecyclePhase.VERIFY;
+
 import io.github.pmckeown.dependencytrack.AbstractDependencyTrackMojo;
 import io.github.pmckeown.dependencytrack.CommonConfig;
 import io.github.pmckeown.dependencytrack.DependencyTrackException;
@@ -8,32 +10,32 @@ import io.github.pmckeown.dependencytrack.policyviolation.report.PolicyViolation
 import io.github.pmckeown.dependencytrack.project.Project;
 import io.github.pmckeown.dependencytrack.project.ProjectAction;
 import io.github.pmckeown.util.Logger;
+import java.io.File;
+import java.util.List;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import java.io.File;
-import java.util.List;
-
-import static org.apache.maven.plugins.annotations.LifecyclePhase.VERIFY;
-
 /**
- * Print the policy violations retrieved from the Dependency Track Server after a BOM upload.  This is calculated
- * immediately by the server and as such can be used in situations where you want to know if a change to your
- * application pom.xml has breached a Policy defined on the Dependency Track server.
- * <p>
- * The build will fail if any Policies are breached that are configured with a violation state of FAIL.
- * <p>
- * The build will pass if any Policies are breached that are configured with a violation state of INFO.
- * <p>
- * The build will pass if any Policies are breached that are configured with a violation state of WARN unless the
- * `failOnWarn` option is supplied.
- * <p>
- * This allows you to tune build failures to your risk appetite.
+ * Print the policy violations retrieved from the Dependency Track Server after a BOM upload. This
+ * is calculated immediately by the server and as such can be used in situations where you want to
+ * know if a change to your application pom.xml has breached a Policy defined on the Dependency
+ * Track server.
+ *
+ * <p>The build will fail if any Policies are breached that are configured with a violation state of
+ * FAIL.
+ *
+ * <p>The build will pass if any Policies are breached that are configured with a violation state of
+ * INFO.
+ *
+ * <p>The build will pass if any Policies are breached that are configured with a violation state of
+ * WARN unless the `failOnWarn` option is supplied.
+ *
+ * <p>This allows you to tune build failures to your risk appetite.
  *
  * @author Sahiba Mittal
  */
@@ -54,9 +56,15 @@ public class PolicyViolationsMojo extends AbstractDependencyTrackMojo {
     private PolicyViolationsAnalyser policyAnalyser;
 
     @Inject
-    public PolicyViolationsMojo(ProjectAction projectAction, PolicyViolationsReportGenerator policyViolationReportGenerator,
-                                CommonConfig commonConfig, ModuleConfig moduleConfig, Logger logger, PolicyViolationsAction policyAction,
-                                PolicyViolationsPrinter policyViolationsPrinter, PolicyViolationsAnalyser policyAnalyser) {
+    public PolicyViolationsMojo(
+            ProjectAction projectAction,
+            PolicyViolationsReportGenerator policyViolationReportGenerator,
+            CommonConfig commonConfig,
+            ModuleConfig moduleConfig,
+            Logger logger,
+            PolicyViolationsAction policyAction,
+            PolicyViolationsPrinter policyViolationsPrinter,
+            PolicyViolationsAnalyser policyAnalyser) {
         super(commonConfig, moduleConfig, logger);
         this.projectAction = projectAction;
         this.policyViolationReportGenerator = policyViolationReportGenerator;
@@ -72,8 +80,8 @@ public class PolicyViolationsMojo extends AbstractDependencyTrackMojo {
             Project project = projectAction.getProject(moduleConfig);
             policyViolations = policyAction.getPolicyViolations(project);
             policyViolationsPrinter.printPolicyViolations(project, policyViolations);
-            boolean policyViolationsBreached = policyAnalyser.isAnyPolicyViolationBreached(policyViolations,
-                    failOnWarn);
+            boolean policyViolationsBreached =
+                    policyAnalyser.isAnyPolicyViolationBreached(policyViolations, failOnWarn);
             policyViolationReportGenerator.generate(getOutputDirectory(), policyViolations);
 
             if (policyViolationsBreached) {

--- a/src/main/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsPrinter.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsPrinter.java
@@ -1,17 +1,15 @@
 package io.github.pmckeown.dependencytrack.policyviolation;
 
-import io.github.pmckeown.dependencytrack.project.Project;
-import io.github.pmckeown.util.Logger;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import java.util.List;
-
 import static io.github.pmckeown.dependencytrack.Constants.DELIMITER;
 
+import io.github.pmckeown.dependencytrack.project.Project;
+import io.github.pmckeown.util.Logger;
+import java.util.List;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
 @Singleton
-public
-class PolicyViolationsPrinter {
+public class PolicyViolationsPrinter {
 
     private Logger logger;
 
@@ -26,18 +24,24 @@ class PolicyViolationsPrinter {
             return;
         }
         logger.info(DELIMITER);
-        logger.info("%d policy violation(s) were retrieved for project: %s", policyViolations.size(),
-                project.getName());
+        logger.info(
+                "%d policy violation(s) were retrieved for project: %s", policyViolations.size(), project.getName());
         logger.info("Printing policy violations for project %s-%s", project.getName(), project.getVersion());
         policyViolations.forEach(policyViolation -> {
             PolicyCondition policyCondition = policyViolation.getPolicyCondition();
             Policy policy = policyCondition.getPolicy();
             logger.info(DELIMITER);
-            logger.info("Policy name: %s (%s)", policy.getName(), policy.getViolationState().name());
-            logger.info("Policy condition: \"subject == %s && value %s %s\"", policyCondition.getSubject(),
-                    policyCondition.getOperator(), policyCondition.getValue());
-            logger.info("Risk type: %s, Component: %s %s", policyViolation.getType(),
-                    policyViolation.getComponent().getName(), policyViolation.getComponent().getVersion());
+            logger.info(
+                    "Policy name: %s (%s)",
+                    policy.getName(), policy.getViolationState().name());
+            logger.info(
+                    "Policy condition: \"subject == %s && value %s %s\"",
+                    policyCondition.getSubject(), policyCondition.getOperator(), policyCondition.getValue());
+            logger.info(
+                    "Risk type: %s, Component: %s %s",
+                    policyViolation.getType(),
+                    policyViolation.getComponent().getName(),
+                    policyViolation.getComponent().getVersion());
             logger.info(""); // Spacer
         });
     }

--- a/src/main/java/io/github/pmckeown/dependencytrack/policyviolation/ViolationState.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/policyviolation/ViolationState.java
@@ -1,5 +1,7 @@
 package io.github.pmckeown.dependencytrack.policyviolation;
 
 public enum ViolationState {
-    FAIL, WARN, INFO
+    FAIL,
+    WARN,
+    INFO
 }

--- a/src/main/java/io/github/pmckeown/dependencytrack/policyviolation/report/PolicyViolationsHtmlReportWriter.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/policyviolation/report/PolicyViolationsHtmlReportWriter.java
@@ -2,11 +2,10 @@ package io.github.pmckeown.dependencytrack.policyviolation.report;
 
 import io.github.pmckeown.dependencytrack.report.AbstractHtmlReportWriter;
 import io.github.pmckeown.dependencytrack.report.TransformerFactoryProvider;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import java.io.File;
 import java.io.InputStream;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 
 @Singleton
 public class PolicyViolationsHtmlReportWriter extends AbstractHtmlReportWriter {
@@ -31,5 +30,4 @@ public class PolicyViolationsHtmlReportWriter extends AbstractHtmlReportWriter {
         return PolicyViolationsHtmlReportWriter.class.getResourceAsStream(
                 PolicyViolationsReportConstants.XSL_STYLESHEET_FILENAME);
     }
-
 }

--- a/src/main/java/io/github/pmckeown/dependencytrack/policyviolation/report/PolicyViolationsReport.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/policyviolation/report/PolicyViolationsReport.java
@@ -2,11 +2,10 @@ package io.github.pmckeown.dependencytrack.policyviolation.report;
 
 import io.github.pmckeown.dependencytrack.policyviolation.PolicyViolation;
 import io.github.pmckeown.dependencytrack.report.Report;
-
+import java.util.List;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-import java.util.List;
 
 @XmlRootElement(name = "policyViolationsReport")
 @XmlType(propOrder = {"policyViolations"})

--- a/src/main/java/io/github/pmckeown/dependencytrack/policyviolation/report/PolicyViolationsReportConstants.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/policyviolation/report/PolicyViolationsReportConstants.java
@@ -8,11 +8,10 @@ class PolicyViolationsReportConstants {
 
     static final String META_INF_DIRECTORY = "/META-INF";
 
-    static final String XSL_STYLESHEET_FILENAME = META_INF_DIRECTORY +
-            "/dependency-track-policy-violations-transformer.xsl";
+    static final String XSL_STYLESHEET_FILENAME =
+            META_INF_DIRECTORY + "/dependency-track-policy-violations-transformer.xsl";
 
     private PolicyViolationsReportConstants() {
         // Do no instantiate
     }
-
 }

--- a/src/main/java/io/github/pmckeown/dependencytrack/policyviolation/report/PolicyViolationsReportGenerator.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/policyviolation/report/PolicyViolationsReportGenerator.java
@@ -2,11 +2,10 @@ package io.github.pmckeown.dependencytrack.policyviolation.report;
 
 import io.github.pmckeown.dependencytrack.DependencyTrackException;
 import io.github.pmckeown.dependencytrack.policyviolation.PolicyViolation;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import java.io.File;
 import java.util.List;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 
 @Singleton
 public class PolicyViolationsReportGenerator {

--- a/src/main/java/io/github/pmckeown/dependencytrack/policyviolation/report/PolicyViolationsWrapper.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/policyviolation/report/PolicyViolationsWrapper.java
@@ -1,10 +1,9 @@
 package io.github.pmckeown.dependencytrack.policyviolation.report;
 
 import io.github.pmckeown.dependencytrack.policyviolation.PolicyViolation;
-
+import java.util.List;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
-import java.util.List;
 
 public class PolicyViolationsWrapper {
 

--- a/src/main/java/io/github/pmckeown/dependencytrack/policyviolation/report/PolicyViolationsXmlReportWriter.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/policyviolation/report/PolicyViolationsXmlReportWriter.java
@@ -1,12 +1,11 @@
 package io.github.pmckeown.dependencytrack.policyviolation.report;
 
 import io.github.pmckeown.dependencytrack.report.AbstractXmlReportWriter;
-
+import java.io.File;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
-import java.io.File;
 
 @Singleton
 public class PolicyViolationsXmlReportWriter extends AbstractXmlReportWriter {
@@ -14,8 +13,8 @@ public class PolicyViolationsXmlReportWriter extends AbstractXmlReportWriter {
     private PolicyViolationsReportMarshallerService policyViolationsReportMarshallerService;
 
     @Inject
-    public PolicyViolationsXmlReportWriter(PolicyViolationsReportMarshallerService
-                policyViolationsReportMarshallerService) {
+    public PolicyViolationsXmlReportWriter(
+            PolicyViolationsReportMarshallerService policyViolationsReportMarshallerService) {
         super();
         this.policyViolationsReportMarshallerService = policyViolationsReportMarshallerService;
     }

--- a/src/main/java/io/github/pmckeown/dependencytrack/project/DeleteProjectMojo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/project/DeleteProjectMojo.java
@@ -1,17 +1,16 @@
 package io.github.pmckeown.dependencytrack.project;
 
+import static java.lang.String.format;
+
 import io.github.pmckeown.dependencytrack.AbstractDependencyTrackMojo;
 import io.github.pmckeown.dependencytrack.CommonConfig;
 import io.github.pmckeown.dependencytrack.DependencyTrackException;
 import io.github.pmckeown.dependencytrack.ModuleConfig;
 import io.github.pmckeown.util.Logger;
+import javax.inject.Inject;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
-
-import javax.inject.Inject;
-
-import static java.lang.String.format;
 
 /**
  * Provides the capability to delete a project on the remote Dependency Track Server.
@@ -24,7 +23,8 @@ public class DeleteProjectMojo extends AbstractDependencyTrackMojo {
     private ProjectAction projectAction;
 
     @Inject
-    public DeleteProjectMojo(ProjectAction projectAction, CommonConfig commonConfig, ModuleConfig moduleConfig, Logger logger) {
+    public DeleteProjectMojo(
+            ProjectAction projectAction, CommonConfig commonConfig, ModuleConfig moduleConfig, Logger logger) {
         super(commonConfig, moduleConfig, logger);
         this.projectAction = projectAction;
     }
@@ -37,12 +37,16 @@ public class DeleteProjectMojo extends AbstractDependencyTrackMojo {
             boolean success = projectAction.deleteProject(project);
 
             if (!success) {
-                handleFailure(format("Failed to delete project: %s-%s", moduleConfig.getProjectName(),
-                        moduleConfig.getProjectVersion()));
+                handleFailure(format(
+                        "Failed to delete project: %s-%s",
+                        moduleConfig.getProjectName(), moduleConfig.getProjectVersion()));
             }
         } catch (DependencyTrackException ex) {
-            handleFailure(format("Exception occurred while trying to delete project: %s-%s",
-                    moduleConfig.getProjectName(), moduleConfig.getProjectVersion()), ex);
+            handleFailure(
+                    format(
+                            "Exception occurred while trying to delete project: %s-%s",
+                            moduleConfig.getProjectName(), moduleConfig.getProjectVersion()),
+                    ex);
         }
     }
 }

--- a/src/main/java/io/github/pmckeown/dependencytrack/project/Project.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/project/Project.java
@@ -4,11 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.github.pmckeown.dependencytrack.Item;
 import io.github.pmckeown.dependencytrack.metrics.Metrics;
-
 import java.util.List;
-
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 
 /**
  * Model class for the Project object
@@ -23,12 +19,13 @@ public class Project extends Item {
     private List<ProjectTag> tags;
 
     @JsonCreator
-    public Project(@JsonProperty("uuid") String uuid,
-                   @JsonProperty("name") String name,
-                   @JsonProperty("version") String version,
-                   @JsonProperty("metrics") Metrics metrics,
-                   @JsonProperty("isLatest") Boolean isLatest,
-                   @JsonProperty("tags") List<ProjectTag> tags) {
+    public Project(
+            @JsonProperty("uuid") String uuid,
+            @JsonProperty("name") String name,
+            @JsonProperty("version") String version,
+            @JsonProperty("metrics") Metrics metrics,
+            @JsonProperty("isLatest") Boolean isLatest,
+            @JsonProperty("tags") List<ProjectTag> tags) {
         super(uuid);
         this.name = name;
         this.version = version;

--- a/src/main/java/io/github/pmckeown/dependencytrack/project/ProjectAction.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/project/ProjectAction.java
@@ -1,5 +1,7 @@
 package io.github.pmckeown.dependencytrack.project;
 
+import static java.lang.String.format;
+
 import com.networknt.schema.utils.StringUtils;
 import io.github.pmckeown.dependencytrack.DependencyTrackException;
 import io.github.pmckeown.dependencytrack.Item;
@@ -7,15 +9,12 @@ import io.github.pmckeown.dependencytrack.ModuleConfig;
 import io.github.pmckeown.dependencytrack.Response;
 import io.github.pmckeown.dependencytrack.bom.BomParser;
 import io.github.pmckeown.util.Logger;
-import kong.unirest.UnirestException;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import java.io.File;
 import java.util.*;
 import java.util.stream.Collectors;
-
-import static java.lang.String.format;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import kong.unirest.UnirestException;
 
 @Singleton
 public class ProjectAction {
@@ -33,9 +32,7 @@ public class ProjectAction {
 
     public Project getProject(ModuleConfig moduleConfig) throws DependencyTrackException {
         return getProject(
-                moduleConfig.getProjectUuid(),
-                moduleConfig.getProjectName(),
-                moduleConfig.getProjectVersion());
+                moduleConfig.getProjectUuid(), moduleConfig.getProjectName(), moduleConfig.getProjectVersion());
     }
 
     public Project getProject(String uuid) throws DependencyTrackException {
@@ -56,13 +53,10 @@ public class ProjectAction {
                     return body.get();
                 } else {
                     if (StringUtils.isBlank(uuid)) {
-                        throw new DependencyTrackException(
-                                format("Requested project not found by UUUID: %s", uuid)
-                        );
+                        throw new DependencyTrackException(format("Requested project not found by UUUID: %s", uuid));
                     } else {
                         throw new DependencyTrackException(
-                                format("Requested project not found by name/version: %s-%s", name, version)
-                        );
+                                format("Requested project not found by name/version: %s-%s", name, version));
                     }
                 }
             } else {
@@ -78,7 +72,8 @@ public class ProjectAction {
         return updateProject(project, updateReq, Collections.emptySet());
     }
 
-    public boolean updateProject(Project project, UpdateRequest updateReq, Set<String> projectTags) throws DependencyTrackException {
+    public boolean updateProject(Project project, UpdateRequest updateReq, Set<String> projectTags)
+            throws DependencyTrackException {
         ProjectInfo info = null;
         if (updateReq.hasBomLocation()) {
             logger.info("Project info will be updated");

--- a/src/main/java/io/github/pmckeown/dependencytrack/project/ProjectClient.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/project/ProjectClient.java
@@ -1,19 +1,18 @@
 package io.github.pmckeown.dependencytrack.project;
 
+import static io.github.pmckeown.dependencytrack.ResourceConstants.V1_PROJECT_LOOKUP;
+import static io.github.pmckeown.dependencytrack.ResourceConstants.V1_PROJECT_UUID;
+import static kong.unirest.Unirest.*;
+
 import io.github.pmckeown.dependencytrack.CommonConfig;
 import io.github.pmckeown.dependencytrack.Response;
+import java.util.Optional;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import kong.unirest.GenericType;
 import kong.unirest.HttpResponse;
 import kong.unirest.HttpStatus;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
-
-import static io.github.pmckeown.dependencytrack.ResourceConstants.V1_PROJECT_UUID;
-import static io.github.pmckeown.dependencytrack.ResourceConstants.V1_PROJECT_LOOKUP;
-import static kong.unirest.Unirest.*;
 
 /**
  * Client for getting Project details from Dependency Track
@@ -50,19 +49,17 @@ public class ProjectClient {
 
     private HttpResponse<Project> getProjectByNameAndVersion(String projectName, String projectVersion) {
         return get(commonConfig.getDependencyTrackBaseUrl() + V1_PROJECT_LOOKUP)
-            .queryString("name", projectName)
-            .queryString("version", projectVersion)
-            .header(X_API_KEY, commonConfig.getApiKey())
-            .asObject(new GenericType<Project>() {
-            });
+                .queryString("name", projectName)
+                .queryString("version", projectVersion)
+                .header(X_API_KEY, commonConfig.getApiKey())
+                .asObject(new GenericType<Project>() {});
     }
 
     private HttpResponse<Project> getProjectByUuid(String uuid) {
         return get(commonConfig.getDependencyTrackBaseUrl() + V1_PROJECT_UUID)
-            .routeParam("uuid", uuid)
-            .header(X_API_KEY, commonConfig.getApiKey())
-            .asObject(new GenericType<Project>() {
-            });
+                .routeParam("uuid", uuid)
+                .header(X_API_KEY, commonConfig.getApiKey())
+                .asObject(new GenericType<Project>() {});
     }
 
     Response<Void> deleteProject(Project project) {

--- a/src/main/java/io/github/pmckeown/dependencytrack/project/ProjectInfo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/project/ProjectInfo.java
@@ -1,14 +1,11 @@
 package io.github.pmckeown.dependencytrack.project;
 
-import io.github.pmckeown.dependencytrack.Item;
-
-import java.util.List;
-
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import io.github.pmckeown.dependencytrack.Item;
+import java.util.List;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 @JsonInclude(Include.NON_NULL)
 public class ProjectInfo {

--- a/src/main/java/io/github/pmckeown/dependencytrack/project/ProjectTag.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/project/ProjectTag.java
@@ -1,11 +1,9 @@
 package io.github.pmckeown.dependencytrack.project;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
-
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class ProjectTag {
 
@@ -26,12 +24,9 @@ public class ProjectTag {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
+        if (this == obj) return true;
+        if (obj == null) return false;
+        if (getClass() != obj.getClass()) return false;
         ProjectTag other = (ProjectTag) obj;
         return Objects.equals(name, other.name);
     }

--- a/src/main/java/io/github/pmckeown/dependencytrack/project/UpdateRequest.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/project/UpdateRequest.java
@@ -5,7 +5,7 @@ public class UpdateRequest {
     private Project parent;
 
     public boolean hasBomLocation() {
-        return bomLocation!=null;
+        return bomLocation != null;
     }
 
     public String getBomLocation() {
@@ -18,7 +18,7 @@ public class UpdateRequest {
     }
 
     public boolean hasParent() {
-        return parent!=null;
+        return parent != null;
     }
 
     public Project getParent() {

--- a/src/main/java/io/github/pmckeown/dependencytrack/report/AbstractHtmlReportWriter.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/report/AbstractHtmlReportWriter.java
@@ -1,16 +1,15 @@
 package io.github.pmckeown.dependencytrack.report;
 
 import io.github.pmckeown.dependencytrack.DependencyTrackException;
-
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
 import javax.xml.XMLConstants;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.InputStream;
 
 public abstract class AbstractHtmlReportWriter {
     protected TransformerFactoryProvider transformerFactoryProvider;

--- a/src/main/java/io/github/pmckeown/dependencytrack/report/AbstractXmlReportWriter.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/report/AbstractXmlReportWriter.java
@@ -1,10 +1,9 @@
 package io.github.pmckeown.dependencytrack.report;
 
 import io.github.pmckeown.dependencytrack.DependencyTrackException;
-
+import java.io.File;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
-import java.io.File;
 
 public abstract class AbstractXmlReportWriter {
 

--- a/src/main/java/io/github/pmckeown/dependencytrack/report/Report.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/report/Report.java
@@ -1,8 +1,4 @@
 package io.github.pmckeown.dependencytrack.report;
 
-/**
- * Marker interface for generic handling of Report instances in Report Writers
- */
-public interface Report {
-
-}
+/** Marker interface for generic handling of Report instances in Report Writers */
+public interface Report {}

--- a/src/main/java/io/github/pmckeown/dependencytrack/score/ScoreAction.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/score/ScoreAction.java
@@ -1,5 +1,8 @@
 package io.github.pmckeown.dependencytrack.score;
 
+import static io.github.pmckeown.dependencytrack.Constants.DELIMITER;
+import static java.lang.String.format;
+
 import io.github.pmckeown.dependencytrack.CommonConfig;
 import io.github.pmckeown.dependencytrack.DependencyTrackException;
 import io.github.pmckeown.dependencytrack.ModuleConfig;
@@ -9,13 +12,9 @@ import io.github.pmckeown.dependencytrack.metrics.MetricsAction;
 import io.github.pmckeown.dependencytrack.project.Project;
 import io.github.pmckeown.dependencytrack.project.ProjectClient;
 import io.github.pmckeown.util.Logger;
-
+import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.Optional;
-
-import static io.github.pmckeown.dependencytrack.Constants.DELIMITER;
-import static java.lang.String.format;
 
 /**
  * Handles score retrieval and processing
@@ -30,22 +29,25 @@ class ScoreAction {
     private Logger logger;
 
     @Inject
-    public ScoreAction(ProjectClient projectClient, MetricsAction metricsAction, CommonConfig commonConfig,
-                       Logger logger) {
+    public ScoreAction(
+            ProjectClient projectClient, MetricsAction metricsAction, CommonConfig commonConfig, Logger logger) {
         this.projectClient = projectClient;
         this.metricsAction = metricsAction;
         this.logger = logger;
     }
 
-    Integer determineScore(ModuleConfig moduleConfig, Integer inheritedRiskScoreThreshold) throws DependencyTrackException {
+    Integer determineScore(ModuleConfig moduleConfig, Integer inheritedRiskScoreThreshold)
+            throws DependencyTrackException {
         try {
-            Response<Project> response = projectClient.getProject(moduleConfig.getProjectUuid(), moduleConfig.getProjectName(), moduleConfig.getProjectVersion());
+            Response<Project> response = projectClient.getProject(
+                    moduleConfig.getProjectUuid(), moduleConfig.getProjectName(), moduleConfig.getProjectVersion());
 
             Optional<Project> body = response.getBody();
             if (response.isSuccess() && body.isPresent()) {
                 return generateResult(body.get(), inheritedRiskScoreThreshold);
             } else {
-                throw new DependencyTrackException(format("Failed to get projects from Dependency Track: %d %s",
+                throw new DependencyTrackException(format(
+                        "Failed to get projects from Dependency Track: %d %s",
                         response.getStatus(), response.getStatusText()));
             }
         } catch (Exception ex) {
@@ -88,5 +90,4 @@ class ScoreAction {
         }
         logger.info(DELIMITER);
     }
-
 }

--- a/src/main/java/io/github/pmckeown/dependencytrack/score/ScoreMojo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/score/ScoreMojo.java
@@ -1,26 +1,27 @@
 package io.github.pmckeown.dependencytrack.score;
 
+import static java.lang.String.format;
+
 import io.github.pmckeown.dependencytrack.AbstractDependencyTrackMojo;
 import io.github.pmckeown.dependencytrack.CommonConfig;
 import io.github.pmckeown.dependencytrack.DependencyTrackException;
 import io.github.pmckeown.dependencytrack.ModuleConfig;
 import io.github.pmckeown.util.Logger;
+import javax.inject.Inject;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
-import javax.inject.Inject;
-
-import static java.lang.String.format;
-
 /**
- * Provides the capability to find the current Inherited Risk Score as determined by the Dependency Track Server.
+ * Provides the capability to find the current Inherited Risk Score as determined by the Dependency
+ * Track Server.
  *
- * Specific configuration options are:
+ * <p>Specific configuration options are:
+ *
  * <ol>
- *     <li>inheritedRiskScoreThreshold</li>
+ *   <li>inheritedRiskScoreThreshold
  * </ol>
  *
  * @author Paul McKeown
@@ -45,19 +46,22 @@ public class ScoreMojo extends AbstractDependencyTrackMojo {
             Integer inheritedRiskScore = scoreAction.determineScore(moduleConfig, inheritedRiskScoreThreshold);
             failBuildIfThresholdIsBreached(inheritedRiskScore);
         } catch (DependencyTrackException ex) {
-            handleFailure(format("Failed to determine score for: %s-%s", moduleConfig.getProjectName(),
-                    moduleConfig.getProjectVersion()));
+            handleFailure(format(
+                    "Failed to determine score for: %s-%s",
+                    moduleConfig.getProjectName(), moduleConfig.getProjectVersion()));
         }
     }
 
     private void failBuildIfThresholdIsBreached(Integer inheritedRiskScore) throws MojoFailureException {
-        logger.debug("Inherited Risk Score Threshold set to: %s",
+        logger.debug(
+                "Inherited Risk Score Threshold set to: %s",
                 inheritedRiskScoreThreshold == null ? "Not set" : inheritedRiskScoreThreshold);
 
         if (inheritedRiskScoreThreshold != null && inheritedRiskScore > inheritedRiskScoreThreshold) {
 
-            throw new MojoFailureException(format("Inherited Risk Score [%d] was greater than the " +
-                    "configured threshold [%d]", inheritedRiskScore, inheritedRiskScoreThreshold));
+            throw new MojoFailureException(format(
+                    "Inherited Risk Score [%d] was greater than the " + "configured threshold [%d]",
+                    inheritedRiskScore, inheritedRiskScoreThreshold));
         }
     }
 

--- a/src/main/java/io/github/pmckeown/dependencytrack/upload/BomClient.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/upload/BomClient.java
@@ -1,21 +1,20 @@
 package io.github.pmckeown.dependencytrack.upload;
 
-import io.github.pmckeown.dependencytrack.CommonConfig;
-import io.github.pmckeown.dependencytrack.Response;
-import io.github.pmckeown.util.Logger;
-import kong.unirest.GenericType;
-import kong.unirest.HttpResponse;
-import kong.unirest.RequestBodyEntity;
-import kong.unirest.Unirest;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import java.util.Optional;
-
 import static io.github.pmckeown.dependencytrack.ResourceConstants.V1_BOM;
 import static io.github.pmckeown.dependencytrack.ResourceConstants.V1_BOM_TOKEN_UUID;
 import static kong.unirest.HeaderNames.CONTENT_TYPE;
 import static kong.unirest.Unirest.get;
+
+import io.github.pmckeown.dependencytrack.CommonConfig;
+import io.github.pmckeown.dependencytrack.Response;
+import io.github.pmckeown.util.Logger;
+import java.util.Optional;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import kong.unirest.GenericType;
+import kong.unirest.HttpResponse;
+import kong.unirest.RequestBodyEntity;
+import kong.unirest.Unirest;
 
 /**
  * Client for uploading BOMs to Dependency Track
@@ -35,20 +34,21 @@ class BomClient {
     }
 
     /**
-     * Upload a BOM to the Dependency-Track server.  The BOM is processed asynchronously after the upload is completed
-     * and the response returned.  The response contains a token that can be used later to query if the bom that the
-     * token relates to has been completely processed.
+     * Upload a BOM to the Dependency-Track server. The BOM is processed asynchronously after the
+     * upload is completed and the response returned. The response contains a token that can be used
+     * later to query if the bom that the token relates to has been completely processed.
      *
      * @param bom the request object containing the project details and the Base64 encoded bom.xml
-     * @return a response containing a token to later determine if processing the supplied BOM is completed
+     * @return a response containing a token to later determine if processing the supplied BOM is
+     *     completed
      */
     Response<UploadBomResponse> uploadBom(UploadBomRequest bom) {
         RequestBodyEntity requestBodyEntity = Unirest.put(commonConfig.getDependencyTrackBaseUrl() + V1_BOM)
                 .header(CONTENT_TYPE, "application/json")
                 .header("X-Api-Key", commonConfig.getApiKey())
                 .body(bom);
-        HttpResponse<UploadBomResponse> httpResponse = requestBodyEntity.asObject(
-                new GenericType<UploadBomResponse>() {});
+        HttpResponse<UploadBomResponse> httpResponse =
+                requestBodyEntity.asObject(new GenericType<UploadBomResponse>() {});
 
         Optional<UploadBomResponse> body;
         if (httpResponse.isSuccess()) {
@@ -64,18 +64,20 @@ class BomClient {
     }
 
     /**
-     * Query the server with a processing token to see if the BOM that it related to has been completely processed.
+     * Query the server with a processing token to see if the BOM that it related to has been
+     * completely processed.
      *
      * @param token The token that was returned from an Upload BOM call
-     * @return a response containing a processing flag.  If the flag is true, processing has not yet completed.  If the
-     *         flag is false, processing is either completed or the token supplied was invalid.
+     * @return a response containing a processing flag. If the flag is true, processing has not yet
+     *     completed. If the flag is false, processing is either completed or the token supplied was
+     *     invalid.
      */
     Response<BomProcessingResponse> isBomBeingProcessed(String token) {
-        final HttpResponse<BomProcessingResponse> httpResponse = get(
-                commonConfig.getDependencyTrackBaseUrl() + V1_BOM_TOKEN_UUID)
+        final HttpResponse<BomProcessingResponse> httpResponse = get(commonConfig.getDependencyTrackBaseUrl()
+                        + V1_BOM_TOKEN_UUID)
                 .header("X-Api-Key", commonConfig.getApiKey())
                 .routeParam("uuid", token)
-                .asObject(new GenericType<BomProcessingResponse>(){});
+                .asObject(new GenericType<BomProcessingResponse>() {});
 
         Optional<BomProcessingResponse> body;
         if (httpResponse.isSuccess()) {

--- a/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomAction.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomAction.java
@@ -5,11 +5,10 @@ import com.evanlennick.retry4j.exception.UnexpectedException;
 import io.github.pmckeown.dependencytrack.*;
 import io.github.pmckeown.util.BomEncoder;
 import io.github.pmckeown.util.Logger;
-import org.apache.commons.lang3.StringUtils;
-
+import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Handles uploading BOMs
@@ -26,8 +25,12 @@ public class UploadBomAction {
     private Poller<Boolean> poller;
 
     @Inject
-    public UploadBomAction(BomClient bomClient, BomEncoder bomEncoder, Poller<Boolean> poller,
-                           CommonConfig commonConfig, Logger logger) {
+    public UploadBomAction(
+            BomClient bomClient,
+            BomEncoder bomEncoder,
+            Poller<Boolean> poller,
+            CommonConfig commonConfig,
+            Logger logger) {
         this.bomClient = bomClient;
         this.bomEncoder = bomEncoder;
         this.poller = poller;
@@ -57,8 +60,7 @@ public class UploadBomAction {
             try {
                 pollUntilBomIsProcessed(uploadBomResponse.get());
             } catch (UnexpectedException | RetriesExhaustedException ex) {
-                logger.error("Polling for processing completion was interrupted so continuing: %s",
-                        ex.getMessage());
+                logger.error("Polling for processing completion was interrupted so continuing: %s", ex.getMessage());
             }
         }
 
@@ -80,18 +82,18 @@ public class UploadBomAction {
         });
     }
 
-    private Optional<UploadBomResponse> doUpload(ModuleConfig moduleConfig, String encodedBom) throws DependencyTrackException {
+    private Optional<UploadBomResponse> doUpload(ModuleConfig moduleConfig, String encodedBom)
+            throws DependencyTrackException {
         try {
-            Response<UploadBomResponse> response = bomClient.uploadBom(
-                    new UploadBomRequest(moduleConfig, encodedBom)
-            );
+            Response<UploadBomResponse> response = bomClient.uploadBom(new UploadBomRequest(moduleConfig, encodedBom));
 
             if (response.isSuccess()) {
                 logger.info("BOM uploaded to Dependency Track server");
                 return response.getBody();
             } else {
-                String message = String.format("Failure integrating with Dependency Track: %d %s", response.getStatus(),
-                        response.getStatusText());
+                String message = String.format(
+                        "Failure integrating with Dependency Track: %d %s",
+                        response.getStatus(), response.getStatusText());
                 logger.error(message);
                 throw new DependencyTrackException(message);
             }

--- a/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojo.java
@@ -9,6 +9,8 @@ import io.github.pmckeown.dependencytrack.project.Project;
 import io.github.pmckeown.dependencytrack.project.ProjectAction;
 import io.github.pmckeown.dependencytrack.project.UpdateRequest;
 import io.github.pmckeown.util.Logger;
+import java.util.Set;
+import javax.inject.Inject;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -17,19 +19,18 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
-import javax.inject.Inject;
-import java.util.Set;
-
 /**
  * Provides the capability to upload a Bill of Material (BOM) to your Dependency Track server.
- * <p>
- * The BOM may any format supported by your Dependency Track server, has only been tested with the output from the
- * <a href="https://github.com/CycloneDX/cyclonedx-maven-plugin">cyclonedx-maven-plugin</a> in the
- * <a href="https://cyclonedx.org/">CycloneDX</a> format
- * <p>
- * Specific configuration options are:
+ *
+ * <p>The BOM may any format supported by your Dependency Track server, has only been tested with
+ * the output from the <a
+ * href="https://github.com/CycloneDX/cyclonedx-maven-plugin">cyclonedx-maven-plugin</a> in the <a
+ * href="https://cyclonedx.org/">CycloneDX</a> format
+ *
+ * <p>Specific configuration options are:
+ *
  * <ol>
- *     <li>bomLocation</li>
+ *   <li>bomLocation
  * </ol>
  *
  * @author Paul McKeown
@@ -71,8 +72,13 @@ public class UploadBomMojo extends AbstractDependencyTrackMojo {
     private final ProjectAction projectAction;
 
     @Inject
-    public UploadBomMojo(UploadBomAction uploadBomAction, MetricsAction metricsAction, ProjectAction projectAction,
-                         CommonConfig commonConfig, ModuleConfig moduleConfig, Logger logger) {
+    public UploadBomMojo(
+            UploadBomAction uploadBomAction,
+            MetricsAction metricsAction,
+            ProjectAction projectAction,
+            CommonConfig commonConfig,
+            ModuleConfig moduleConfig,
+            Logger logger) {
         super(commonConfig, moduleConfig, logger);
         this.uploadBomAction = uploadBomAction;
         this.metricsAction = metricsAction;
@@ -130,8 +136,7 @@ public class UploadBomMojo extends AbstractDependencyTrackMojo {
         } else {
             if (StringUtils.isBlank(moduleConfig.getParentUuid()))
                 return getProjectParentByNameAndVersion(moduleConfig.getParentName(), moduleConfig.getParentVersion());
-            else
-                return getProjectParentByUuid(moduleConfig.getParentUuid());
+            else return getProjectParentByUuid(moduleConfig.getParentUuid());
         }
     }
 
@@ -140,9 +145,11 @@ public class UploadBomMojo extends AbstractDependencyTrackMojo {
         try {
             return projectAction.getProject(uuid);
         } catch (DependencyTrackException ex) {
-            logger.error("Failed to find parent project with UUID ['%s']. Check the update parent " +
-                    "your settings for this plugin and verify if a matching parent project exists in the " +
-                    "server.", uuid);
+            logger.error(
+                    "Failed to find parent project with UUID ['%s']. Check the update parent "
+                            + "your settings for this plugin and verify if a matching parent project exists in the "
+                            + "server.",
+                    uuid);
             throw ex;
         }
     }
@@ -152,9 +159,11 @@ public class UploadBomMojo extends AbstractDependencyTrackMojo {
         try {
             return projectAction.getProject(name, version);
         } catch (DependencyTrackException ex) {
-            logger.error("Failed to find parent project with name ['%s-%s']. Check the update parent " +
-                    "your settings for this plugin and verify if a matching parent project exists in the " +
-                    "server.", name, version);
+            logger.error(
+                    "Failed to find parent project with name ['%s-%s']. Check the update parent "
+                            + "your settings for this plugin and verify if a matching parent project exists in the "
+                            + "server.",
+                    name, version);
             throw ex;
         }
     }

--- a/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomRequest.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/upload/UploadBomRequest.java
@@ -1,18 +1,15 @@
 package io.github.pmckeown.dependencytrack.upload;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.github.pmckeown.dependencytrack.ModuleConfig;
 import io.github.pmckeown.dependencytrack.project.ProjectTag;
-
+import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Encapsulates the request payload for uploading a BOM
@@ -40,7 +37,8 @@ public class UploadBomRequest {
         if (CollectionUtils.isEmpty(moduleConfig.getProjectTags())) {
             this.projectTags = null;
         } else {
-            this.projectTags = moduleConfig.getProjectTags().stream().map(ProjectTag::new).collect(Collectors.toList());
+            this.projectTags =
+                    moduleConfig.getProjectTags().stream().map(ProjectTag::new).collect(Collectors.toList());
         }
         this.parentUUID = moduleConfig.getParentUuid();
         if (StringUtils.isNoneBlank(moduleConfig.getParentName(), moduleConfig.getParentVersion())) {

--- a/src/main/java/io/github/pmckeown/util/BomEncoder.java
+++ b/src/main/java/io/github/pmckeown/util/BomEncoder.java
@@ -1,13 +1,11 @@
 package io.github.pmckeown.util;
 
-
-import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.io.IOUtils;
-
-import javax.inject.Singleton;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Optional;
+import javax.inject.Singleton;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.io.IOUtils;
 
 /**
  * Encodes a BOM file in the Base64 format.
@@ -20,8 +18,9 @@ public class BomEncoder {
     /**
      * Encodes the file found at the provided location.
      *
-     * Guarantees to return an {@link Optional} containing the Base64 encoded file if one is found at the provided
-     * location.  An empty {@link Optional} will be returned if the file location if invalid or the file cannot be read.
+     * <p>Guarantees to return an {@link Optional} containing the Base64 encoded file if one is found
+     * at the provided location. An empty {@link Optional} will be returned if the file location if
+     * invalid or the file cannot be read.
      *
      * @param bomLocation the location to find the file to encode
      * @param logger Common logging wrapper

--- a/src/main/java/io/github/pmckeown/util/Logger.java
+++ b/src/main/java/io/github/pmckeown/util/Logger.java
@@ -1,11 +1,11 @@
 package io.github.pmckeown.util;
 
+import javax.inject.Singleton;
 import org.apache.maven.plugin.logging.Log;
 
-import javax.inject.Singleton;
-
 /**
- * Wrapper service around the Maven {@link Log} implementation.  Provides convenient shortcuts to common log methods.
+ * Wrapper service around the Maven {@link Log} implementation. Provides convenient shortcuts to
+ * common log methods.
  *
  * @author Paul McKeown
  */
@@ -18,7 +18,7 @@ public class Logger {
         // For dependency injection
     }
 
-    public Logger (Log log) {
+    public Logger(Log log) {
         // For testing
         this.log = log;
     }
@@ -35,21 +35,21 @@ public class Logger {
 
     public void info(String template, Object... params) {
         assertLogSupplied();
-        if(log.isInfoEnabled()) {
+        if (log.isInfoEnabled()) {
             log.info(String.format(template, params));
         }
     }
 
     public void warn(String template, Object... params) {
         assertLogSupplied();
-        if(log.isWarnEnabled()) {
+        if (log.isWarnEnabled()) {
             log.warn(String.format(template, params));
         }
     }
 
     public void debug(String template, Object... params) {
         assertLogSupplied();
-        if(log.isDebugEnabled()) {
+        if (log.isDebugEnabled()) {
             log.debug(String.format(template, params));
         }
     }
@@ -60,7 +60,7 @@ public class Logger {
 
     public void error(String template, Object... params) {
         assertLogSupplied();
-        if(log.isErrorEnabled()) {
+        if (log.isErrorEnabled()) {
             log.error(String.format(template, params));
         }
     }

--- a/src/test/java/io/github/pmckeown/TestMojoLoader.java
+++ b/src/test/java/io/github/pmckeown/TestMojoLoader.java
@@ -1,19 +1,18 @@
 package io.github.pmckeown;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import io.github.pmckeown.dependencytrack.finding.FindingsMojo;
 import io.github.pmckeown.dependencytrack.metrics.MetricsMojo;
 import io.github.pmckeown.dependencytrack.policyviolation.PolicyViolationsMojo;
 import io.github.pmckeown.dependencytrack.project.DeleteProjectMojo;
-import io.github.pmckeown.dependencytrack.upload.UploadBomMojo;
 import io.github.pmckeown.dependencytrack.score.ScoreMojo;
-import org.apache.maven.plugin.testing.MojoRule;
-
+import io.github.pmckeown.dependencytrack.upload.UploadBomMojo;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import org.apache.maven.plugin.testing.MojoRule;
 
 /**
  * Helper class to load Mojos
@@ -24,9 +23,7 @@ public final class TestMojoLoader {
 
     private static final String TEST_RESOURCES = "target/test-classes/projects/run/";
 
-    private TestMojoLoader() {
-
-    }
+    private TestMojoLoader() {}
 
     public static UploadBomMojo loadUploadBomMojo(MojoRule mojoRule) throws Exception {
         UploadBomMojo uploadBomMojo = (UploadBomMojo) mojoRule.lookupConfiguredMojo(getPomFile(), "upload-bom");
@@ -50,8 +47,8 @@ public final class TestMojoLoader {
     }
 
     public static DeleteProjectMojo loadDeleteProjectMojo(MojoRule mojoRule) throws Exception {
-        DeleteProjectMojo deleteProjectMojo = (DeleteProjectMojo) mojoRule.lookupConfiguredMojo(getPomFile(),
-                "delete-project");
+        DeleteProjectMojo deleteProjectMojo =
+                (DeleteProjectMojo) mojoRule.lookupConfiguredMojo(getPomFile(), "delete-project");
         deleteProjectMojo.setPluginContext(getPluginContext());
         assertNotNull(deleteProjectMojo);
         return deleteProjectMojo;
@@ -65,8 +62,8 @@ public final class TestMojoLoader {
     }
 
     public static PolicyViolationsMojo loadPolicyMojo(MojoRule mojoRule) throws Exception {
-        PolicyViolationsMojo policyMojo = (PolicyViolationsMojo) mojoRule.lookupConfiguredMojo(getPomFile(),
-                "policy-violations");
+        PolicyViolationsMojo policyMojo =
+                (PolicyViolationsMojo) mojoRule.lookupConfiguredMojo(getPomFile(), "policy-violations");
         policyMojo.setPluginContext(getPluginContext());
         assertNotNull(policyMojo);
         return policyMojo;

--- a/src/test/java/io/github/pmckeown/dependencytrack/AbstractDependencyTrackIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/AbstractDependencyTrackIntegrationTest.java
@@ -1,13 +1,13 @@
 package io.github.pmckeown.dependencytrack;
 
+import static io.github.pmckeown.dependencytrack.ObjectMapperFactory.relaxedObjectMapper;
+import static kong.unirest.HeaderNames.ACCEPT;
+import static kong.unirest.HeaderNames.ACCEPT_ENCODING;
+
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import kong.unirest.Unirest;
 import kong.unirest.jackson.JacksonObjectMapper;
 import org.junit.Rule;
-
-import static io.github.pmckeown.dependencytrack.ObjectMapperFactory.relaxedObjectMapper;
-import static kong.unirest.HeaderNames.ACCEPT;
-import static kong.unirest.HeaderNames.ACCEPT_ENCODING;
 
 /**
  * Base class for Dependency Track integrations
@@ -17,10 +17,12 @@ import static kong.unirest.HeaderNames.ACCEPT_ENCODING;
 public abstract class AbstractDependencyTrackIntegrationTest {
 
     /**
-     * Initialise Unirest manually as the initialisation in {@link AbstractDependencyTrackMojo} will not get executed
+     * Initialise Unirest manually as the initialisation in {@link AbstractDependencyTrackMojo} will
+     * not get executed
      */
     static {
-        Unirest.config().setObjectMapper(new JacksonObjectMapper(relaxedObjectMapper()))
+        Unirest.config()
+                .setObjectMapper(new JacksonObjectMapper(relaxedObjectMapper()))
                 .addDefaultHeader(ACCEPT_ENCODING, "gzip, deflate")
                 .addDefaultHeader(ACCEPT, "application/json");
     }
@@ -47,5 +49,4 @@ public abstract class AbstractDependencyTrackIntegrationTest {
         config.setProjectVersion(PROJECT_VERSION);
         return config;
     }
-
 }

--- a/src/test/java/io/github/pmckeown/dependencytrack/ModuleConfigTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/ModuleConfigTest.java
@@ -1,5 +1,11 @@
 package io.github.pmckeown.dependencytrack;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.doReturn;
+
+import java.io.File;
 import org.apache.maven.project.MavenProject;
 import org.junit.Before;
 import org.junit.Test;
@@ -7,13 +13,6 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import java.io.File;
-
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.doReturn;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ModuleConfigTest {

--- a/src/test/java/io/github/pmckeown/dependencytrack/ObjectMapperFactoryTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/ObjectMapperFactoryTest.java
@@ -1,17 +1,16 @@
 package io.github.pmckeown.dependencytrack;
 
+import static org.junit.Assert.assertNotNull;
+
 import io.github.pmckeown.dependencytrack.project.Project;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 import kong.unirest.GenericType;
 import kong.unirest.jackson.JacksonObjectMapper;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
-
-import java.io.File;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
-
-import static org.junit.Assert.assertNotNull;
 
 public class ObjectMapperFactoryTest {
 
@@ -19,11 +18,13 @@ public class ObjectMapperFactoryTest {
     public void thatUnknownPropertiesAreIgnoredWhenDeserializingJson() throws Exception {
         JacksonObjectMapper om = new JacksonObjectMapper(ObjectMapperFactory.relaxedObjectMapper());
 
-        List<Project> projects = om.readValue(IOUtils.toString(FileUtils.openInputStream(
-                new File("src/test/resources/__files/api/v1/project/get-all-projects.json")), StandardCharsets.UTF_8),
-                new GenericType<List<Project>>(){});
+        List<Project> projects = om.readValue(
+                IOUtils.toString(
+                        FileUtils.openInputStream(
+                                new File("src/test/resources/__files/api/v1/project/get-all-projects.json")),
+                        StandardCharsets.UTF_8),
+                new GenericType<List<Project>>() {});
 
         assertNotNull(projects);
-
     }
 }

--- a/src/test/java/io/github/pmckeown/dependencytrack/PollerTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/PollerTest.java
@@ -1,13 +1,5 @@
 package io.github.pmckeown.dependencytrack;
 
-import com.evanlennick.retry4j.exception.RetriesExhaustedException;
-import com.evanlennick.retry4j.exception.UnexpectedException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
-
-import java.util.Optional;
-
 import static io.github.pmckeown.dependencytrack.PollingConfig.TimeUnit.MILLIS;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -15,6 +7,13 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
+
+import com.evanlennick.retry4j.exception.RetriesExhaustedException;
+import com.evanlennick.retry4j.exception.UnexpectedException;
+import java.util.Optional;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PollerTest {
@@ -36,14 +35,14 @@ public class PollerTest {
 
     @Test
     public void thatThatEmptyOptionalLoopsTheMaximumNumberOfTimesThenThrowsException() {
-        PollingConfig pollingConfig = new PollingConfig(true, 1 ,5, MILLIS);
+        PollingConfig pollingConfig = new PollingConfig(true, 1, 5, MILLIS);
         Poller<String> poller = new Poller<>();
         final int[] pollLoopCounter = {0};
 
         try {
             Optional<String> optionalString = poller.poll(pollingConfig, () -> {
-                    pollLoopCounter[0]++;
-                    return Optional.empty();
+                pollLoopCounter[0]++;
+                return Optional.empty();
             });
             fail("RetriesExhaustedException expected");
         } catch (Exception ex) {
@@ -54,7 +53,7 @@ public class PollerTest {
 
     @Test
     public void thatThatExceptionDuringPollingExitsWithException() {
-        PollingConfig pollingConfig = new PollingConfig(true, 1 ,1, MILLIS);
+        PollingConfig pollingConfig = new PollingConfig(true, 1, 1, MILLIS);
         Poller<String> poller = new Poller<>();
 
         try {
@@ -70,7 +69,7 @@ public class PollerTest {
 
     @Test
     public void IfPollingDisabledTheCallableIsExecutedOnlyOnce() {
-        PollingConfig pollingConfig = new PollingConfig(false, 1 ,5, MILLIS);
+        PollingConfig pollingConfig = new PollingConfig(false, 1, 5, MILLIS);
         Poller<String> poller = new Poller<>();
         final int[] pollLoopCounter = {0};
 

--- a/src/test/java/io/github/pmckeown/dependencytrack/PollingConfigTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/PollingConfigTest.java
@@ -1,12 +1,11 @@
 package io.github.pmckeown.dependencytrack;
 
-import org.junit.Test;
-
-import java.time.temporal.ChronoUnit;
-
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.time.temporal.ChronoUnit;
+import org.junit.Test;
 
 public class PollingConfigTest {
 

--- a/src/test/java/io/github/pmckeown/dependencytrack/TestResourceConstants.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/TestResourceConstants.java
@@ -4,7 +4,8 @@ public class TestResourceConstants {
 
     public static final String V1_METRICS_PROJECT_CURRENT = "/api/v1/metrics/project/(.*)/current";
     public static final String V1_METRICS_PROJECT_REFRESH = "/api/v1/metrics/project/(.*)/refresh";
-    public static final String V1_PROJECT_UUID = "/api/v1/project/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})";
+    public static final String V1_PROJECT_UUID =
+            "/api/v1/project/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})";
     public static final String V1_BOM_TOKEN_UUID = "/api/v1/bom/token/(.*)";
     public static final String V1_FINDING_PROJECT_UUID = "/api/v1/finding/project/(.*)";
     public static final String V1_POLICY_VIOLATION_PROJECT_UUID = "/api/v1/violation/project/(.*)";

--- a/src/test/java/io/github/pmckeown/dependencytrack/ThresholdsTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/ThresholdsTest.java
@@ -1,9 +1,9 @@
 package io.github.pmckeown.dependencytrack;
 
-import org.junit.Test;
-
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
 
 public class ThresholdsTest {
 

--- a/src/test/java/io/github/pmckeown/dependencytrack/bom/BomParserTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/bom/BomParserTest.java
@@ -1,18 +1,17 @@
 package io.github.pmckeown.dependencytrack.bom;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import io.github.pmckeown.dependencytrack.project.ProjectInfo;
 import io.github.pmckeown.util.Logger;
+import java.io.File;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import java.io.File;
-
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 @RunWith(MockitoJUnitRunner.class)
 public class BomParserTest {
@@ -28,21 +27,31 @@ public class BomParserTest {
         File bomFile = new File(BomParserTest.class.getResource("bom.xml").getFile());
         ProjectInfo info = bomParser.getProjectInfo(bomFile).get();
         assertThat(info.getGroup(), is(equalTo("io.github.pmckeown")));
-        assertThat(info.getDescription(), is(equalTo("Maven plugin to integrate with a Dependency Track server to " +
-                "submit dependency manifests and gather project metrics.")));
-        assertThat(info.getPurl(), is(equalTo("pkg:maven/io.github.pmckeown/dependency-track-maven-plugin@1.2.1-" +
-                "SNAPSHOT?type=maven-plugin")));
+        assertThat(
+                info.getDescription(),
+                is(equalTo("Maven plugin to integrate with a Dependency Track server to "
+                        + "submit dependency manifests and gather project metrics.")));
+        assertThat(
+                info.getPurl(),
+                is(equalTo("pkg:maven/io.github.pmckeown/dependency-track-maven-plugin@1.2.1-"
+                        + "SNAPSHOT?type=maven-plugin")));
         assertThat(info.getClassifier(), is(equalTo("LIBRARY")));
     }
+
     @Test
     public void thatProjectInfoCanBeParsedFromBomWithByteOrder() {
-        File bomFile = new File(BomParserTest.class.getResource("bom_byteorder.xml").getFile());
+        File bomFile =
+                new File(BomParserTest.class.getResource("bom_byteorder.xml").getFile());
         ProjectInfo info = bomParser.getProjectInfo(bomFile).get();
         assertThat(info.getGroup(), is(equalTo("io.github.pmckeown")));
-        assertThat(info.getDescription(), is(equalTo("Maven plugin to integrate with a Dependency Track server to " +
-                "submit dependency manifests and gather project metrics.")));
-        assertThat(info.getPurl(), is(equalTo("pkg:maven/io.github.pmckeown/dependency-track-maven-plugin@1.2.1-" +
-                "SNAPSHOT?type=maven-plugin")));
+        assertThat(
+                info.getDescription(),
+                is(equalTo("Maven plugin to integrate with a Dependency Track server to "
+                        + "submit dependency manifests and gather project metrics.")));
+        assertThat(
+                info.getPurl(),
+                is(equalTo("pkg:maven/io.github.pmckeown/dependency-track-maven-plugin@1.2.1-"
+                        + "SNAPSHOT?type=maven-plugin")));
         assertThat(info.getClassifier(), is(equalTo("LIBRARY")));
     }
 
@@ -53,13 +62,15 @@ public class BomParserTest {
 
     @Test
     public void thatEmptyIsReturnedWhenBomHasNoMetadata() {
-        File bomFile = new File(BomParserTest.class.getResource("bom-without-metadata.xml").getFile());
+        File bomFile = new File(
+                BomParserTest.class.getResource("bom-without-metadata.xml").getFile());
         assertThat(bomParser.getProjectInfo(bomFile).isPresent(), is(equalTo(false)));
     }
 
     @Test
     public void thatEmptyIsReturnedWhenBomHasNoMetadataComponent() {
-        File bomFile = new File(BomParserTest.class.getResource("bom-without-component.xml").getFile());
+        File bomFile = new File(
+                BomParserTest.class.getResource("bom-without-component.xml").getFile());
         assertThat(bomParser.getProjectInfo(bomFile).isPresent(), is(equalTo(false)));
     }
 

--- a/src/test/java/io/github/pmckeown/dependencytrack/finding/FindingsActionTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/finding/FindingsActionTest.java
@@ -1,25 +1,13 @@
 package io.github.pmckeown.dependencytrack.finding;
 
-import io.github.pmckeown.dependencytrack.DependencyTrackException;
-import io.github.pmckeown.dependencytrack.project.Project;
-import io.github.pmckeown.util.Logger;
-import kong.unirest.UnirestException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-
-import java.util.List;
-
-import static io.github.pmckeown.dependencytrack.finding.AnalysisBuilder.anAnalysis;
-import static io.github.pmckeown.dependencytrack.project.ProjectBuilder.aProject;
 import static io.github.pmckeown.dependencytrack.ResponseBuilder.aNotFoundResponse;
 import static io.github.pmckeown.dependencytrack.ResponseBuilder.aSuccessResponse;
+import static io.github.pmckeown.dependencytrack.finding.AnalysisBuilder.anAnalysis;
 import static io.github.pmckeown.dependencytrack.finding.ComponentBuilder.aComponent;
 import static io.github.pmckeown.dependencytrack.finding.FindingBuilder.aFinding;
 import static io.github.pmckeown.dependencytrack.finding.FindingListBuilder.aListOfFindings;
 import static io.github.pmckeown.dependencytrack.finding.VulnerabilityBuilder.aVulnerability;
+import static io.github.pmckeown.dependencytrack.project.ProjectBuilder.aProject;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -27,6 +15,17 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+
+import io.github.pmckeown.dependencytrack.DependencyTrackException;
+import io.github.pmckeown.dependencytrack.project.Project;
+import io.github.pmckeown.util.Logger;
+import java.util.List;
+import kong.unirest.UnirestException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class FindingsActionTest {
@@ -49,7 +48,9 @@ public class FindingsActionTest {
                         .withVulnerability(aVulnerability())
                         .withComponent(aComponent()))
                 .build();
-        doReturn(aSuccessResponse().withBody(findings).build()).when(findingClient).getFindingsForProject(project);
+        doReturn(aSuccessResponse().withBody(findings).build())
+                .when(findingClient)
+                .getFindingsForProject(project);
 
         List<Finding> returnedFindings = findingAction.getFindings(project);
 

--- a/src/test/java/io/github/pmckeown/dependencytrack/finding/FindingsAnalyserTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/finding/FindingsAnalyserTest.java
@@ -1,15 +1,5 @@
 package io.github.pmckeown.dependencytrack.finding;
 
-import io.github.pmckeown.util.Logger;
-import org.apache.maven.plugin.MojoFailureException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-
-import java.util.List;
-
 import static io.github.pmckeown.dependencytrack.finding.Analysis.State.FALSE_POSITIVE;
 import static io.github.pmckeown.dependencytrack.finding.AnalysisBuilder.anAnalysis;
 import static io.github.pmckeown.dependencytrack.finding.FindingBuilder.aDefaultFinding;
@@ -22,9 +12,18 @@ import static io.github.pmckeown.dependencytrack.finding.Severity.UNASSIGNED;
 import static io.github.pmckeown.dependencytrack.finding.VulnerabilityBuilder.aVulnerability;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
+
+import io.github.pmckeown.util.Logger;
+import java.util.List;
+import org.apache.maven.plugin.MojoFailureException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class FindingsAnalyserTest {
@@ -37,16 +36,18 @@ public class FindingsAnalyserTest {
 
     @Test
     public void thatWhenNoThresholdIsProvidedThePolicyCannotBeBreached() {
-        boolean isPolicyBreached = findingAnalyser.doNumberOfFindingsBreachPolicy(
-                aListOfFindings().build(), null);
+        boolean isPolicyBreached =
+                findingAnalyser.doNumberOfFindingsBreachPolicy(aListOfFindings().build(), null);
 
         assertFalse(isPolicyBreached);
     }
 
     @Test
     public void thatACriticalIssueCountGreaterThanTheDefinedThresholdWillThrowMojoFailureException() {
-        List<Finding> findings = aListOfFindings().withFinding(
-                aDefaultFinding().withVulnerability(aVulnerability().withSeverity(CRITICAL))).build();
+        List<Finding> findings = aListOfFindings()
+                .withFinding(
+                        aDefaultFinding().withVulnerability(aVulnerability().withSeverity(CRITICAL)))
+                .build();
 
         try {
             findingAnalyser.doNumberOfFindingsBreachPolicy(findings, new FindingThresholds(0, null, null, null, null));
@@ -57,8 +58,10 @@ public class FindingsAnalyserTest {
 
     @Test
     public void thatACriticalIssueCountLessThanTheDefinedThresholdWillNotThrowMojoFailureException() {
-        List<Finding> findings = aListOfFindings().withFinding(
-                aDefaultFinding().withVulnerability(aVulnerability().withSeverity(CRITICAL))).build();
+        List<Finding> findings = aListOfFindings()
+                .withFinding(
+                        aDefaultFinding().withVulnerability(aVulnerability().withSeverity(CRITICAL)))
+                .build();
 
         try {
             findingAnalyser.doNumberOfFindingsBreachPolicy(findings, new FindingThresholds(2, 0, 0, 0, 0));
@@ -69,10 +72,11 @@ public class FindingsAnalyserTest {
 
     @Test
     public void thatASuppressedCriticalIssueCountWillNotThrowMojoFailureException() {
-        List<Finding> findings = aListOfFindings().withFinding(
-                aDefaultFinding()
+        List<Finding> findings = aListOfFindings()
+                .withFinding(aDefaultFinding()
                         .withVulnerability(aVulnerability().withSeverity(CRITICAL))
-                        .withAnalysis(anAnalysis().withSuppressed(true).withState(FALSE_POSITIVE))).build();
+                        .withAnalysis(anAnalysis().withSuppressed(true).withState(FALSE_POSITIVE)))
+                .build();
 
         try {
             findingAnalyser.doNumberOfFindingsBreachPolicy(findings, new FindingThresholds(0, null, null, null, null));
@@ -83,8 +87,10 @@ public class FindingsAnalyserTest {
 
     @Test
     public void thatAHighIssueCountGreaterThanTheDefinedThresholdWillThrowMojoFailureException() {
-        List<Finding> findings = aListOfFindings().withFinding(
-                aDefaultFinding().withVulnerability(aVulnerability().withSeverity(HIGH))).build();
+        List<Finding> findings = aListOfFindings()
+                .withFinding(
+                        aDefaultFinding().withVulnerability(aVulnerability().withSeverity(HIGH)))
+                .build();
 
         try {
             findingAnalyser.doNumberOfFindingsBreachPolicy(findings, new FindingThresholds(null, 0, null, null, null));
@@ -95,8 +101,10 @@ public class FindingsAnalyserTest {
 
     @Test
     public void thatAHighIssueCountLessThanTheDefinedThresholdWillNotThrowMojoFailureException() {
-        List<Finding> findings = aListOfFindings().withFinding(
-                aDefaultFinding().withVulnerability(aVulnerability().withSeverity(HIGH))).build();
+        List<Finding> findings = aListOfFindings()
+                .withFinding(
+                        aDefaultFinding().withVulnerability(aVulnerability().withSeverity(HIGH)))
+                .build();
 
         try {
             findingAnalyser.doNumberOfFindingsBreachPolicy(findings, new FindingThresholds(0, 2, 0, 0, 0));
@@ -107,10 +115,11 @@ public class FindingsAnalyserTest {
 
     @Test
     public void thatASuppressedHighIssueCountWillNotThrowMojoFailureException() {
-        List<Finding> findings = aListOfFindings().withFinding(
-                aDefaultFinding()
+        List<Finding> findings = aListOfFindings()
+                .withFinding(aDefaultFinding()
                         .withVulnerability(aVulnerability().withSeverity(HIGH))
-                        .withAnalysis(anAnalysis().withSuppressed(true).withState(FALSE_POSITIVE))).build();
+                        .withAnalysis(anAnalysis().withSuppressed(true).withState(FALSE_POSITIVE)))
+                .build();
 
         try {
             findingAnalyser.doNumberOfFindingsBreachPolicy(findings, new FindingThresholds(null, 0, null, null, null));
@@ -121,8 +130,10 @@ public class FindingsAnalyserTest {
 
     @Test
     public void thatAMediumIssueCountGreaterThanTheDefinedThresholdWillThrowMojoFailureException() {
-        List<Finding> findings = aListOfFindings().withFinding(
-                aDefaultFinding().withVulnerability(aVulnerability().withSeverity(MEDIUM))).build();
+        List<Finding> findings = aListOfFindings()
+                .withFinding(
+                        aDefaultFinding().withVulnerability(aVulnerability().withSeverity(MEDIUM)))
+                .build();
 
         try {
             findingAnalyser.doNumberOfFindingsBreachPolicy(findings, new FindingThresholds(null, null, 0, null, null));
@@ -133,8 +144,10 @@ public class FindingsAnalyserTest {
 
     @Test
     public void thatAMediumIssueCountLessThanTheDefinedThresholdWillNotThrowMojoFailureException() {
-        List<Finding> findings = aListOfFindings().withFinding(
-                aDefaultFinding().withVulnerability(aVulnerability().withSeverity(MEDIUM))).build();
+        List<Finding> findings = aListOfFindings()
+                .withFinding(
+                        aDefaultFinding().withVulnerability(aVulnerability().withSeverity(MEDIUM)))
+                .build();
 
         try {
             findingAnalyser.doNumberOfFindingsBreachPolicy(findings, new FindingThresholds(0, 0, 2, 0, 0));
@@ -145,10 +158,11 @@ public class FindingsAnalyserTest {
 
     @Test
     public void thatASuppressedMediumIssueCountWillNotThrowMojoFailureException() {
-        List<Finding> findings = aListOfFindings().withFinding(
-                aDefaultFinding()
+        List<Finding> findings = aListOfFindings()
+                .withFinding(aDefaultFinding()
                         .withVulnerability(aVulnerability().withSeverity(MEDIUM))
-                        .withAnalysis(anAnalysis().withSuppressed(true).withState(FALSE_POSITIVE))).build();
+                        .withAnalysis(anAnalysis().withSuppressed(true).withState(FALSE_POSITIVE)))
+                .build();
 
         try {
             findingAnalyser.doNumberOfFindingsBreachPolicy(findings, new FindingThresholds(null, null, 0, null, null));
@@ -159,8 +173,10 @@ public class FindingsAnalyserTest {
 
     @Test
     public void thatALowIssueCountGreaterThanTheDefinedThresholdWillThrowMojoFailureException() {
-        List<Finding> findings = aListOfFindings().withFinding(
-                aDefaultFinding().withVulnerability(aVulnerability().withSeverity(LOW))).build();
+        List<Finding> findings = aListOfFindings()
+                .withFinding(
+                        aDefaultFinding().withVulnerability(aVulnerability().withSeverity(LOW)))
+                .build();
 
         try {
             findingAnalyser.doNumberOfFindingsBreachPolicy(findings, new FindingThresholds(null, null, null, 0, null));
@@ -171,8 +187,10 @@ public class FindingsAnalyserTest {
 
     @Test
     public void thatALowIssueCountLessThanTheDefinedThresholdWillNotThrowMojoFailureException() {
-        List<Finding> findings = aListOfFindings().withFinding(
-                aDefaultFinding().withVulnerability(aVulnerability().withSeverity(LOW))).build();
+        List<Finding> findings = aListOfFindings()
+                .withFinding(
+                        aDefaultFinding().withVulnerability(aVulnerability().withSeverity(LOW)))
+                .build();
 
         try {
             findingAnalyser.doNumberOfFindingsBreachPolicy(findings, new FindingThresholds(0, 0, 0, 2, 0));
@@ -183,10 +201,11 @@ public class FindingsAnalyserTest {
 
     @Test
     public void thatASuppressedLowIssueCountWillNotThrowMojoFailureException() {
-        List<Finding> findings = aListOfFindings().withFinding(
-                aDefaultFinding()
+        List<Finding> findings = aListOfFindings()
+                .withFinding(aDefaultFinding()
                         .withVulnerability(aVulnerability().withSeverity(LOW))
-                        .withAnalysis(anAnalysis().withSuppressed(true).withState(FALSE_POSITIVE))).build();
+                        .withAnalysis(anAnalysis().withSuppressed(true).withState(FALSE_POSITIVE)))
+                .build();
 
         try {
             findingAnalyser.doNumberOfFindingsBreachPolicy(findings, new FindingThresholds(null, null, null, 0, null));
@@ -197,8 +216,10 @@ public class FindingsAnalyserTest {
 
     @Test
     public void thatAUnassignedIssueCountGreaterThanTheDefinedThresholdWillThrowMojoFailureException() {
-        List<Finding> findings = aListOfFindings().withFinding(
-                aDefaultFinding().withVulnerability(aVulnerability().withSeverity(UNASSIGNED))).build();
+        List<Finding> findings = aListOfFindings()
+                .withFinding(
+                        aDefaultFinding().withVulnerability(aVulnerability().withSeverity(UNASSIGNED)))
+                .build();
 
         try {
             findingAnalyser.doNumberOfFindingsBreachPolicy(findings, new FindingThresholds(null, null, null, null, 0));
@@ -209,8 +230,10 @@ public class FindingsAnalyserTest {
 
     @Test
     public void thatAUnassignedIssueCountLessThanTheDefinedThresholdWillNotThrowMojoFailureException() {
-        List<Finding> findings = aListOfFindings().withFinding(
-                aDefaultFinding().withVulnerability(aVulnerability().withSeverity(UNASSIGNED))).build();
+        List<Finding> findings = aListOfFindings()
+                .withFinding(
+                        aDefaultFinding().withVulnerability(aVulnerability().withSeverity(UNASSIGNED)))
+                .build();
 
         try {
             findingAnalyser.doNumberOfFindingsBreachPolicy(findings, new FindingThresholds(0, 0, 0, 0, 2));
@@ -221,10 +244,11 @@ public class FindingsAnalyserTest {
 
     @Test
     public void thatASuppressedUnassignedIssueCountWillNotThrowMojoFailureException() {
-        List<Finding> findings = aListOfFindings().withFinding(
-                aDefaultFinding()
+        List<Finding> findings = aListOfFindings()
+                .withFinding(aDefaultFinding()
                         .withVulnerability(aVulnerability().withSeverity(UNASSIGNED))
-                        .withAnalysis(anAnalysis().withSuppressed(true).withState(FALSE_POSITIVE))).build();
+                        .withAnalysis(anAnalysis().withSuppressed(true).withState(FALSE_POSITIVE)))
+                .build();
 
         try {
             findingAnalyser.doNumberOfFindingsBreachPolicy(findings, new FindingThresholds(null, null, null, null, 0));

--- a/src/test/java/io/github/pmckeown/dependencytrack/finding/FindingsClientTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/finding/FindingsClientTest.java
@@ -1,20 +1,5 @@
 package io.github.pmckeown.dependencytrack.finding;
 
-import com.github.tomakehurst.wiremock.http.Fault;
-import io.github.pmckeown.dependencytrack.AbstractDependencyTrackIntegrationTest;
-import io.github.pmckeown.dependencytrack.Response;
-import io.github.pmckeown.util.Logger;
-import kong.unirest.UnirestException;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-
-import java.util.List;
-import java.util.Optional;
-
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.badRequest;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -25,12 +10,12 @@ import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static io.github.pmckeown.dependencytrack.TestResourceConstants.V1_FINDING_PROJECT_UUID;
 import static io.github.pmckeown.dependencytrack.TestUtils.asJson;
 import static io.github.pmckeown.dependencytrack.finding.AnalysisBuilder.anAnalysis;
-import static io.github.pmckeown.dependencytrack.finding.Severity.LOW;
-import static io.github.pmckeown.dependencytrack.project.ProjectBuilder.aProject;
 import static io.github.pmckeown.dependencytrack.finding.ComponentBuilder.aComponent;
 import static io.github.pmckeown.dependencytrack.finding.FindingBuilder.aFinding;
 import static io.github.pmckeown.dependencytrack.finding.FindingListBuilder.aListOfFindings;
+import static io.github.pmckeown.dependencytrack.finding.Severity.LOW;
 import static io.github.pmckeown.dependencytrack.finding.VulnerabilityBuilder.aVulnerability;
+import static io.github.pmckeown.dependencytrack.project.ProjectBuilder.aProject;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -38,6 +23,20 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
+
+import com.github.tomakehurst.wiremock.http.Fault;
+import io.github.pmckeown.dependencytrack.AbstractDependencyTrackIntegrationTest;
+import io.github.pmckeown.dependencytrack.Response;
+import io.github.pmckeown.util.Logger;
+import java.util.List;
+import java.util.Optional;
+import kong.unirest.UnirestException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class FindingsClientTest extends AbstractDependencyTrackIntegrationTest {
@@ -55,16 +54,17 @@ public class FindingsClientTest extends AbstractDependencyTrackIntegrationTest {
 
     @Test
     public void thatFindingsCanBeRetrieved() throws Exception {
-        stubFor(get(urlPathMatching(V1_FINDING_PROJECT_UUID)).willReturn(
-                aResponse().withBody(asJson(
-                        aListOfFindings()
-                                .withFinding(
-                                        aFinding()
-                                                .withComponent(aComponent().withName("dodgy"))
-                                                .withVulnerability(aVulnerability().withSeverity(LOW))
-                                                .withAnalysis(anAnalysis())).build()))));
+        stubFor(get(urlPathMatching(V1_FINDING_PROJECT_UUID))
+                .willReturn(aResponse()
+                        .withBody(asJson(aListOfFindings()
+                                .withFinding(aFinding()
+                                        .withComponent(aComponent().withName("dodgy"))
+                                        .withVulnerability(aVulnerability().withSeverity(LOW))
+                                        .withAnalysis(anAnalysis()))
+                                .build()))));
 
-        Response<List<Finding>> response = findingClient.getFindingsForProject(aProject().build());
+        Response<List<Finding>> response =
+                findingClient.getFindingsForProject(aProject().build());
 
         verify(1, getRequestedFor(urlPathMatching(V1_FINDING_PROJECT_UUID)));
         assertThat(response.isSuccess(), is(equalTo(true)));
@@ -84,7 +84,8 @@ public class FindingsClientTest extends AbstractDependencyTrackIntegrationTest {
     public void thatFailureToGetFindingsReturnsAnErrorResponse() {
         stubFor(get(urlPathMatching(V1_FINDING_PROJECT_UUID)).willReturn(badRequest()));
 
-        Response<List<Finding>> response = findingClient.getFindingsForProject(aProject().build());
+        Response<List<Finding>> response =
+                findingClient.getFindingsForProject(aProject().build());
 
         verify(1, getRequestedFor(urlPathMatching(V1_FINDING_PROJECT_UUID)));
         assertThat(response.isSuccess(), is(equalTo(false)));
@@ -93,8 +94,8 @@ public class FindingsClientTest extends AbstractDependencyTrackIntegrationTest {
 
     @Test
     public void thatAnErrorToGetFindingsThrowsException() {
-        stubFor(get(urlPathMatching(V1_FINDING_PROJECT_UUID)).willReturn(
-                aResponse().withFault(Fault.RANDOM_DATA_THEN_CLOSE)));
+        stubFor(get(urlPathMatching(V1_FINDING_PROJECT_UUID))
+                .willReturn(aResponse().withFault(Fault.RANDOM_DATA_THEN_CLOSE)));
 
         try {
             findingClient.getFindingsForProject(aProject().build());
@@ -103,5 +104,4 @@ public class FindingsClientTest extends AbstractDependencyTrackIntegrationTest {
             assertThat(ex, is(instanceOf(UnirestException.class)));
         }
     }
-
 }

--- a/src/test/java/io/github/pmckeown/dependencytrack/finding/FindingsMojoIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/finding/FindingsMojoIntegrationTest.java
@@ -1,11 +1,5 @@
 package io.github.pmckeown.dependencytrack.finding;
 
-import io.github.pmckeown.dependencytrack.AbstractDependencyTrackMojoTest;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
-import org.junit.Before;
-import org.junit.Test;
-
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -29,6 +23,12 @@ import static io.github.pmckeown.dependencytrack.finding.Severity.UNASSIGNED;
 import static io.github.pmckeown.dependencytrack.finding.VulnerabilityBuilder.aVulnerability;
 import static org.junit.Assert.fail;
 
+import io.github.pmckeown.dependencytrack.AbstractDependencyTrackMojoTest;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.junit.Before;
+import org.junit.Test;
+
 public class FindingsMojoIntegrationTest extends AbstractDependencyTrackMojoTest {
 
     private FindingsMojo findingsMojo;
@@ -44,16 +44,16 @@ public class FindingsMojoIntegrationTest extends AbstractDependencyTrackMojoTest
 
     @Test
     public void thatFindingMojoCanRetrieveFindingsAndPrintThem() throws Exception {
-        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP)).willReturn(
-                aResponse().withBodyFile("api/v1/project/testName-project.json")));
-        stubFor(get(urlPathMatching(V1_FINDING_PROJECT_UUID)).willReturn(
-                aResponse().withBody(asJson(
-                        aListOfFindings()
-                                .withFinding(
-                                        aFinding()
-                                                .withComponent(aComponent().withName("dodgy"))
-                                                .withVulnerability(aVulnerability().withSeverity(LOW))
-                                                .withAnalysis(anAnalysis())).build()))));
+        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP))
+                .willReturn(aResponse().withBodyFile("api/v1/project/testName-project.json")));
+        stubFor(get(urlPathMatching(V1_FINDING_PROJECT_UUID))
+                .willReturn(aResponse()
+                        .withBody(asJson(aListOfFindings()
+                                .withFinding(aFinding()
+                                        .withComponent(aComponent().withName("dodgy"))
+                                        .withVulnerability(aVulnerability().withSeverity(LOW))
+                                        .withAnalysis(anAnalysis()))
+                                .build()))));
 
         findingsMojo.execute();
 
@@ -63,8 +63,8 @@ public class FindingsMojoIntegrationTest extends AbstractDependencyTrackMojoTest
 
     @Test
     public void thatWhenNoFindingsAreFoundTheMojoDoesNotFail() throws Exception {
-        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP)).willReturn(
-                aResponse().withBodyFile("api/v1/project/testName-project.json")));
+        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP))
+                .willReturn(aResponse().withBodyFile("api/v1/project/testName-project.json")));
         stubFor(get(urlPathMatching(V1_FINDING_PROJECT_UUID)).willReturn(ok()));
 
         try {
@@ -78,9 +78,10 @@ public class FindingsMojoIntegrationTest extends AbstractDependencyTrackMojoTest
 
     @Test(expected = MojoExecutionException.class)
     public void thatWhenExceptionOccursWhileGettingFindingsAndFailOnErrorIsTrueTheMojoErrors() throws Exception {
-        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP)).willReturn(
-                aResponse().withBodyFile("api/v1/project/testName-project.json")));
-        stubFor(get(urlPathMatching(V1_FINDING_PROJECT_UUID)).willReturn(aResponse().withFault(RANDOM_DATA_THEN_CLOSE)));
+        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP))
+                .willReturn(aResponse().withBodyFile("api/v1/project/testName-project.json")));
+        stubFor(get(urlPathMatching(V1_FINDING_PROJECT_UUID))
+                .willReturn(aResponse().withFault(RANDOM_DATA_THEN_CLOSE)));
 
         findingsMojo.setFailOnError(true);
 
@@ -90,16 +91,16 @@ public class FindingsMojoIntegrationTest extends AbstractDependencyTrackMojoTest
 
     @Test(expected = MojoFailureException.class)
     public void thatBuildFailsWhenFindingsNumberBreachesDefinedThresholds() throws Exception {
-        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP)).willReturn(
-                aResponse().withBodyFile("api/v1/project/testName-project.json")));
-        stubFor(get(urlPathMatching(V1_FINDING_PROJECT_UUID)).willReturn(
-                aResponse().withBody(asJson(
-                        aListOfFindings()
-                                .withFinding(
-                                        aFinding()
-                                                .withComponent(aComponent().withName("dodgy"))
-                                                .withVulnerability(aVulnerability().withSeverity(LOW))
-                                                .withAnalysis(anAnalysis())).build()))));
+        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP))
+                .willReturn(aResponse().withBodyFile("api/v1/project/testName-project.json")));
+        stubFor(get(urlPathMatching(V1_FINDING_PROJECT_UUID))
+                .willReturn(aResponse()
+                        .withBody(asJson(aListOfFindings()
+                                .withFinding(aFinding()
+                                        .withComponent(aComponent().withName("dodgy"))
+                                        .withVulnerability(aVulnerability().withSeverity(LOW))
+                                        .withAnalysis(anAnalysis()))
+                                .build()))));
 
         findingsMojo.setFindingThresholds(new FindingThresholds(0, 0, 0, 0, 0));
 
@@ -109,16 +110,16 @@ public class FindingsMojoIntegrationTest extends AbstractDependencyTrackMojoTest
 
     @Test
     public void thatBuildDoesNotFailWhenOnlyUnassignedFindingExists() throws Exception {
-        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP)).willReturn(
-                aResponse().withBodyFile("api/v1/project/testName-project.json")));
-        stubFor(get(urlPathMatching(V1_FINDING_PROJECT_UUID)).willReturn(
-                aResponse().withBody(asJson(
-                        aListOfFindings()
-                                .withFinding(
-                                        aFinding()
-                                                .withComponent(aComponent().withName("dodgy"))
-                                                .withVulnerability(aVulnerability().withSeverity(UNASSIGNED))
-                                                .withAnalysis(anAnalysis())).build()))));
+        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP))
+                .willReturn(aResponse().withBodyFile("api/v1/project/testName-project.json")));
+        stubFor(get(urlPathMatching(V1_FINDING_PROJECT_UUID))
+                .willReturn(aResponse()
+                        .withBody(asJson(aListOfFindings()
+                                .withFinding(aFinding()
+                                        .withComponent(aComponent().withName("dodgy"))
+                                        .withVulnerability(aVulnerability().withSeverity(UNASSIGNED))
+                                        .withAnalysis(anAnalysis()))
+                                .build()))));
 
         findingsMojo.setFindingThresholds(new FindingThresholds());
 
@@ -131,16 +132,16 @@ public class FindingsMojoIntegrationTest extends AbstractDependencyTrackMojoTest
 
     @Test
     public void thatFindingsIsSkippedWhenSkipIsTrue() throws Exception {
-        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP)).willReturn(
-                aResponse().withBodyFile("api/v1/project/testName-project.json")));
-        stubFor(get(urlPathMatching(V1_FINDING_PROJECT_UUID)).willReturn(
-                aResponse().withBody(asJson(
-                        aListOfFindings()
-                                .withFinding(
-                                        aFinding()
-                                                .withComponent(aComponent().withName("dodgy"))
-                                                .withVulnerability(aVulnerability().withSeverity(LOW))
-                                                .withAnalysis(anAnalysis())).build()))));
+        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP))
+                .willReturn(aResponse().withBodyFile("api/v1/project/testName-project.json")));
+        stubFor(get(urlPathMatching(V1_FINDING_PROJECT_UUID))
+                .willReturn(aResponse()
+                        .withBody(asJson(aListOfFindings()
+                                .withFinding(aFinding()
+                                        .withComponent(aComponent().withName("dodgy"))
+                                        .withVulnerability(aVulnerability().withSeverity(LOW))
+                                        .withAnalysis(anAnalysis()))
+                                .build()))));
 
         findingsMojo.setSkip("true");
 

--- a/src/test/java/io/github/pmckeown/dependencytrack/finding/FindingsMojoTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/finding/FindingsMojoTest.java
@@ -1,25 +1,24 @@
 package io.github.pmckeown.dependencytrack.finding;
 
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
 import io.github.pmckeown.dependencytrack.CommonConfig;
 import io.github.pmckeown.dependencytrack.ModuleConfig;
 import io.github.pmckeown.dependencytrack.finding.report.FindingsReportGenerator;
 import io.github.pmckeown.dependencytrack.project.ProjectAction;
 import io.github.pmckeown.util.Logger;
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.maven.plugin.MojoFailureException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
 
 @SuppressWarnings("unused")
 @RunWith(MockitoJUnitRunner.class)
@@ -56,8 +55,7 @@ public class FindingsMojoTest {
     public void thatReportIsAlwaysGeneratedEvenWhenNoFindingsArePresent() throws Exception {
         findingsMojo.performAction();
 
-        verify(findingsReportGenerator, times(1)).generate(
-                null, new ArrayList<>(), null, false);
+        verify(findingsReportGenerator, times(1)).generate(null, new ArrayList<>(), null, false);
     }
 
     @Test
@@ -71,8 +69,9 @@ public class FindingsMojoTest {
 
     @Test
     public void thatThresholdLowOptionCanBeSetDirectly() throws Exception {
-        doReturn(true).when(findingsAnalyser).doNumberOfFindingsBreachPolicy(
-                any(List.class), any(FindingThresholds.class));
+        doReturn(true)
+                .when(findingsAnalyser)
+                .doNumberOfFindingsBreachPolicy(any(List.class), any(FindingThresholds.class));
 
         findingsMojo.setThresholdLow(1);
 
@@ -118,5 +117,4 @@ public class FindingsMojoTest {
         findingsMojo.populateThresholdFromCliOptions();
         assertThat(findingsMojo.getFindingThresholds().getUnassigned(), is(equalTo(1)));
     }
-
 }

--- a/src/test/java/io/github/pmckeown/dependencytrack/finding/FindingsPrinterTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/finding/FindingsPrinterTest.java
@@ -1,15 +1,5 @@
 package io.github.pmckeown.dependencytrack.finding;
 
-import io.github.pmckeown.dependencytrack.project.Project;
-import io.github.pmckeown.util.Logger;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-
-import java.util.List;
-
 import static io.github.pmckeown.dependencytrack.Constants.DELIMITER;
 import static io.github.pmckeown.dependencytrack.finding.Analysis.State.FALSE_POSITIVE;
 import static io.github.pmckeown.dependencytrack.finding.AnalysisBuilder.anAnalysis;
@@ -23,6 +13,15 @@ import static org.apache.commons.lang3.RandomStringUtils.randomNumeric;
 import static org.apache.commons.lang3.StringUtils.repeat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+
+import io.github.pmckeown.dependencytrack.project.Project;
+import io.github.pmckeown.util.Logger;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class FindingsPrinterTest {
@@ -111,9 +110,7 @@ public class FindingsPrinterTest {
         verify(logger).info("be vulnerable.> > -- [redhat.com](https://bugzilla.redhat.com/show_bug");
     }
 
-    /**
-     * Test for issue: https://github.com/pmckeown/dependency-track-maven-plugin/issues/281
-     */
+    /** Test for issue: https://github.com/pmckeown/dependency-track-maven-plugin/issues/281 */
     @Test
     public void thatSanitisedContentPrintableWhenItShrinksAcrossAChunkBoundary() {
         int chunkSize = findingsPrinter.getPrintWidth();
@@ -129,25 +126,20 @@ public class FindingsPrinterTest {
 
     private List<Finding> findingsList(boolean isSuppressed, final VulnerabilityBuilder vulnerabilityBuilder) {
         return aListOfFindings()
-                .withFinding(
-                        aFinding()
-                                .withComponent(
-                                        aComponent()
-                                                .withGroup("nz.co.dodgy")
-                                                .withName("insecure-encrypter")
-                                                .withVersion("20.0"))
-                                .withVulnerability(vulnerabilityBuilder)
-                                .withAnalysis(
-                                        anAnalysis()
-                                                .withSuppressed(isSuppressed)
-                                                .withState(Analysis.State.FALSE_POSITIVE))).build();
+                .withFinding(aFinding()
+                        .withComponent(aComponent()
+                                .withGroup("nz.co.dodgy")
+                                .withName("insecure-encrypter")
+                                .withVersion("20.0"))
+                        .withVulnerability(vulnerabilityBuilder)
+                        .withAnalysis(
+                                anAnalysis().withSuppressed(isSuppressed).withState(Analysis.State.FALSE_POSITIVE)))
+                .build();
     }
 
     private List<Finding> findingsList(String longDescription, String vulnId, boolean isSuppressed) {
-        VulnerabilityBuilder vulnerabilityBuilder = aVulnerability()
-                .withSeverity(HIGH)
-                .withVulnId(vulnId)
-                .withDescription(longDescription);
+        VulnerabilityBuilder vulnerabilityBuilder =
+                aVulnerability().withSeverity(HIGH).withVulnId(vulnId).withDescription(longDescription);
         return findingsList(isSuppressed, vulnerabilityBuilder);
     }
 

--- a/src/test/java/io/github/pmckeown/dependencytrack/finding/VulnerabilityBuilder.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/finding/VulnerabilityBuilder.java
@@ -1,8 +1,8 @@
 package io.github.pmckeown.dependencytrack.finding;
 
-import java.util.UUID;
-
 import static org.apache.commons.lang3.RandomStringUtils.randomNumeric;
+
+import java.util.UUID;
 
 public class VulnerabilityBuilder {
 

--- a/src/test/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportGeneratorTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportGeneratorTest.java
@@ -1,16 +1,5 @@
 package io.github.pmckeown.dependencytrack.finding.report;
 
-import io.github.pmckeown.dependencytrack.DependencyTrackException;
-import io.github.pmckeown.dependencytrack.finding.Finding;
-import io.github.pmckeown.dependencytrack.finding.FindingThresholds;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-
-import java.util.List;
-
 import static io.github.pmckeown.dependencytrack.finding.FindingListBuilder.aListOfFindings;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -21,6 +10,16 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+
+import io.github.pmckeown.dependencytrack.DependencyTrackException;
+import io.github.pmckeown.dependencytrack.finding.Finding;
+import io.github.pmckeown.dependencytrack.finding.FindingThresholds;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class FindingsReportGeneratorTest {

--- a/src/test/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportHtmlReportWriterTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportHtmlReportWriterTest.java
@@ -1,17 +1,16 @@
 package io.github.pmckeown.dependencytrack.finding.report;
 
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
 import io.github.pmckeown.dependencytrack.report.TransformerFactoryProvider;
+import javax.xml.XMLConstants;
+import javax.xml.transform.TransformerFactory;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import javax.xml.XMLConstants;
-import javax.xml.transform.TransformerFactory;
-
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class FindingsReportHtmlReportWriterTest {

--- a/src/test/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportIntegrationTest.java
@@ -1,16 +1,5 @@
 package io.github.pmckeown.dependencytrack.finding.report;
 
-import io.github.pmckeown.dependencytrack.finding.Analysis;
-import io.github.pmckeown.dependencytrack.finding.Finding;
-import io.github.pmckeown.dependencytrack.finding.FindingThresholds;
-import io.github.pmckeown.dependencytrack.finding.Severity;
-import io.github.pmckeown.dependencytrack.report.TransformerFactoryProvider;
-import org.junit.Before;
-import org.junit.Test;
-
-import java.io.File;
-import java.util.List;
-
 import static io.github.pmckeown.dependencytrack.finding.AnalysisBuilder.anAnalysis;
 import static io.github.pmckeown.dependencytrack.finding.ComponentBuilder.aComponent;
 import static io.github.pmckeown.dependencytrack.finding.FindingBuilder.aFinding;
@@ -19,6 +8,16 @@ import static io.github.pmckeown.dependencytrack.finding.VulnerabilityBuilder.aV
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
+
+import io.github.pmckeown.dependencytrack.finding.Analysis;
+import io.github.pmckeown.dependencytrack.finding.Finding;
+import io.github.pmckeown.dependencytrack.finding.FindingThresholds;
+import io.github.pmckeown.dependencytrack.finding.Severity;
+import io.github.pmckeown.dependencytrack.report.TransformerFactoryProvider;
+import java.io.File;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
 
 public class FindingsReportIntegrationTest {
 
@@ -69,7 +68,9 @@ public class FindingsReportIntegrationTest {
                 .withFinding(aFinding()
                         .withVulnerability(aVulnerability().withSeverity(Severity.CRITICAL))
                         .withComponent(aComponent().withName("suppressed"))
-                        .withAnalysis(anAnalysis().withState(Analysis.State.FALSE_POSITIVE).withSuppressed(true)))
+                        .withAnalysis(anAnalysis()
+                                .withState(Analysis.State.FALSE_POSITIVE)
+                                .withSuppressed(true)))
                 .withFinding(aFinding()
                         .withVulnerability(aVulnerability().withSeverity(Severity.HIGH))
                         .withComponent(aComponent())

--- a/src/test/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportTest.java
@@ -1,12 +1,5 @@
 package io.github.pmckeown.dependencytrack.finding.report;
 
-import io.github.pmckeown.dependencytrack.finding.Finding;
-import io.github.pmckeown.dependencytrack.finding.FindingThresholds;
-import io.github.pmckeown.dependencytrack.finding.Severity;
-import org.junit.Test;
-
-import java.util.List;
-
 import static io.github.pmckeown.dependencytrack.finding.AnalysisBuilder.anAnalysis;
 import static io.github.pmckeown.dependencytrack.finding.ComponentBuilder.aComponent;
 import static io.github.pmckeown.dependencytrack.finding.FindingBuilder.aFinding;
@@ -15,6 +8,12 @@ import static io.github.pmckeown.dependencytrack.finding.VulnerabilityBuilder.aV
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+
+import io.github.pmckeown.dependencytrack.finding.Finding;
+import io.github.pmckeown.dependencytrack.finding.FindingThresholds;
+import io.github.pmckeown.dependencytrack.finding.Severity;
+import java.util.List;
+import org.junit.Test;
 
 public class FindingsReportTest {
 
@@ -25,14 +24,13 @@ public class FindingsReportTest {
                 .withFinding(aFinding()
                         .withAnalysis(anAnalysis())
                         .withVulnerability(aVulnerability())
-                        .withComponent(aComponent()
-                                .withName("shonky-lib")))
+                        .withComponent(aComponent().withName("shonky-lib")))
                 .build();
         FindingsReport findingsReport = new FindingsReport(findingThresholds, findings, true);
 
         assertThat(findingsReport.getCritical().getCount(), is(equalTo(1)));
-        assertThat(findingsReport.getCritical().getFindings().get(0).getComponent().getName(),
-                is(equalTo("shonky-lib")));
+        assertThat(
+                findingsReport.getCritical().getFindings().get(0).getComponent().getName(), is(equalTo("shonky-lib")));
     }
 
     @Test
@@ -68,5 +66,4 @@ public class FindingsReportTest {
         assertThat(findingsReport.getLow().getCount(), is(equalTo(1)));
         assertThat(findingsReport.getUnassigned().getCount(), is(equalTo(1)));
     }
-
 }

--- a/src/test/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportXmlReportWriterTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/finding/report/FindingsReportXmlReportWriterTest.java
@@ -1,20 +1,5 @@
 package io.github.pmckeown.dependencytrack.finding.report;
 
-import io.github.pmckeown.dependencytrack.DependencyTrackException;
-import io.github.pmckeown.dependencytrack.finding.Finding;
-import io.github.pmckeown.dependencytrack.finding.FindingThresholds;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-import java.io.File;
-import java.util.List;
-
 import static io.github.pmckeown.dependencytrack.finding.AnalysisBuilder.anAnalysis;
 import static io.github.pmckeown.dependencytrack.finding.ComponentBuilder.aComponent;
 import static io.github.pmckeown.dependencytrack.finding.FindingBuilder.aFinding;
@@ -27,6 +12,20 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+
+import io.github.pmckeown.dependencytrack.DependencyTrackException;
+import io.github.pmckeown.dependencytrack.finding.Finding;
+import io.github.pmckeown.dependencytrack.finding.FindingThresholds;
+import java.io.File;
+import java.util.List;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class FindingsReportXmlReportWriterTest {

--- a/src/test/java/io/github/pmckeown/dependencytrack/metrics/MetricsActionTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/metrics/MetricsActionTest.java
@@ -1,5 +1,21 @@
 package io.github.pmckeown.dependencytrack.metrics;
 
+import static io.github.pmckeown.dependencytrack.ResponseBuilder.aNotFoundResponse;
+import static io.github.pmckeown.dependencytrack.ResponseBuilder.aSuccessResponse;
+import static io.github.pmckeown.dependencytrack.project.ProjectBuilder.aProject;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
 import io.github.pmckeown.dependencytrack.CommonConfig;
 import io.github.pmckeown.dependencytrack.DependencyTrackException;
 import io.github.pmckeown.dependencytrack.Poller;
@@ -13,22 +29,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import static io.github.pmckeown.dependencytrack.project.ProjectBuilder.aProject;
-import static io.github.pmckeown.dependencytrack.ResponseBuilder.aNotFoundResponse;
-import static io.github.pmckeown.dependencytrack.ResponseBuilder.aSuccessResponse;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MetricsActionTest {
@@ -52,7 +52,9 @@ public class MetricsActionTest {
 
     @Test
     public void thatMetricsCanBeRetrieved() throws Exception {
-        doReturn(aSuccessResponse().withBody(aMetrics()).build()).when(metricsClient).getMetrics(any(Project.class));
+        doReturn(aSuccessResponse().withBody(aMetrics()).build())
+                .when(metricsClient)
+                .getMetrics(any(Project.class));
         doReturn(PollingConfig.defaults()).when(commonConfig).getPollingConfig();
 
         Metrics metrics = metricsAction.getMetrics(aProject().build());

--- a/src/test/java/io/github/pmckeown/dependencytrack/metrics/MetricsAnalyserTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/metrics/MetricsAnalyserTest.java
@@ -1,5 +1,17 @@
 package io.github.pmckeown.dependencytrack.metrics;
 
+import static io.github.pmckeown.dependencytrack.Constants.CRITICAL;
+import static io.github.pmckeown.dependencytrack.Constants.HIGH;
+import static io.github.pmckeown.dependencytrack.Constants.LOW;
+import static io.github.pmckeown.dependencytrack.Constants.MEDIUM;
+import static io.github.pmckeown.dependencytrack.Constants.UNASSIGNED;
+import static io.github.pmckeown.dependencytrack.metrics.MetricsAnalyser.ERROR_TEMPLATE;
+import static io.github.pmckeown.dependencytrack.metrics.MetricsBuilder.aMetrics;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.verify;
+
 import io.github.pmckeown.util.Logger;
 import org.apache.maven.plugin.MojoFailureException;
 import org.junit.Test;
@@ -7,18 +19,6 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import static io.github.pmckeown.dependencytrack.Constants.CRITICAL;
-import static io.github.pmckeown.dependencytrack.Constants.HIGH;
-import static io.github.pmckeown.dependencytrack.Constants.MEDIUM;
-import static io.github.pmckeown.dependencytrack.Constants.LOW;
-import static io.github.pmckeown.dependencytrack.Constants.UNASSIGNED;
-import static io.github.pmckeown.dependencytrack.metrics.MetricsBuilder.aMetrics;
-import static io.github.pmckeown.dependencytrack.metrics.MetricsAnalyser.ERROR_TEMPLATE;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MetricsAnalyserTest {
@@ -106,7 +106,8 @@ public class MetricsAnalyserTest {
                 .withHigh(200)
                 .withMedium(300)
                 .withLow(400)
-                .withUnassigned(500).build();
+                .withUnassigned(500)
+                .build();
 
         try {
             metricsAnalyser.analyse(metrics, new MetricsThresholds(0, 0, 0, 0, 0));

--- a/src/test/java/io/github/pmckeown/dependencytrack/metrics/MetricsBuilder.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/metrics/MetricsBuilder.java
@@ -20,8 +20,7 @@ public class MetricsBuilder {
     private Date firstOccurrence = new Date();
     private Date lastOccurrence = new Date();
 
-    private MetricsBuilder() {
-    }
+    private MetricsBuilder() {}
 
     public static MetricsBuilder aMetrics() {
         return new MetricsBuilder();
@@ -103,8 +102,21 @@ public class MetricsBuilder {
     }
 
     public Metrics build() {
-        return new Metrics(inheritedRiskScore, critical, high, medium, low, unassigned, vulnerabilities,
-                vulnerableComponents, components, suppressed, findingsTotal, findingsAudited, findingsUnaudited,
-                firstOccurrence, lastOccurrence);
+        return new Metrics(
+                inheritedRiskScore,
+                critical,
+                high,
+                medium,
+                low,
+                unassigned,
+                vulnerabilities,
+                vulnerableComponents,
+                components,
+                suppressed,
+                findingsTotal,
+                findingsAudited,
+                findingsUnaudited,
+                firstOccurrence,
+                lastOccurrence);
     }
 }

--- a/src/test/java/io/github/pmckeown/dependencytrack/metrics/MetricsClientTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/metrics/MetricsClientTest.java
@@ -1,19 +1,5 @@
 package io.github.pmckeown.dependencytrack.metrics;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import io.github.pmckeown.dependencytrack.CommonConfig;
-import io.github.pmckeown.dependencytrack.Response;
-import io.github.pmckeown.util.Logger;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-
-import java.util.Date;
-import java.util.Optional;
-
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
@@ -27,6 +13,19 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.doReturn;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import io.github.pmckeown.dependencytrack.CommonConfig;
+import io.github.pmckeown.dependencytrack.Response;
+import io.github.pmckeown.util.Logger;
+import java.util.Date;
+import java.util.Optional;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MetricsClientTest {
@@ -47,8 +46,8 @@ public class MetricsClientTest {
     public void thatMetricsAreReturnedCorrectly() {
         doReturn("http://localhost:" + wireMockRule.port()).when(commonConfig).getDependencyTrackBaseUrl();
         doReturn("api123").when(commonConfig).getApiKey();
-        stubFor(get(urlPathMatching(V1_METRICS_PROJECT_CURRENT)).willReturn(
-                aResponse().withBodyFile("api/v1/metrics/project/project-metrics.json")));
+        stubFor(get(urlPathMatching(V1_METRICS_PROJECT_CURRENT))
+                .willReturn(aResponse().withBodyFile("api/v1/metrics/project/project-metrics.json")));
 
         Response<Metrics> metricsResponse = metricsClient.getMetrics(aProject().build());
 

--- a/src/test/java/io/github/pmckeown/dependencytrack/metrics/MetricsMojoIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/metrics/MetricsMojoIntegrationTest.java
@@ -1,15 +1,5 @@
 package io.github.pmckeown.dependencytrack.metrics;
 
-import com.github.tomakehurst.wiremock.http.Fault;
-import io.github.pmckeown.dependencytrack.AbstractDependencyTrackMojoTest;
-import io.github.pmckeown.dependencytrack.PollingConfig;
-import io.github.pmckeown.dependencytrack.project.ProjectBuilder;
-
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
-import org.junit.Before;
-import org.junit.Test;
-
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -25,6 +15,15 @@ import static io.github.pmckeown.dependencytrack.TestUtils.asJson;
 import static io.github.pmckeown.dependencytrack.metrics.MetricsBuilder.aMetrics;
 import static org.junit.Assert.fail;
 
+import com.github.tomakehurst.wiremock.http.Fault;
+import io.github.pmckeown.dependencytrack.AbstractDependencyTrackMojoTest;
+import io.github.pmckeown.dependencytrack.PollingConfig;
+import io.github.pmckeown.dependencytrack.project.ProjectBuilder;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.junit.Before;
+import org.junit.Test;
+
 public class MetricsMojoIntegrationTest extends AbstractDependencyTrackMojoTest {
 
     private MetricsMojo metricsMojo;
@@ -38,8 +37,8 @@ public class MetricsMojoIntegrationTest extends AbstractDependencyTrackMojoTest 
 
     @Test
     public void thatMetricsCanBeRetrievedForCurrentProject() throws Exception {
-        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP)).willReturn(
-                aResponse().withBodyFile("api/v1/project/testName-project.json")));
+        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP))
+                .willReturn(aResponse().withBodyFile("api/v1/project/testName-project.json")));
 
         metricsMojo.setProjectName("testName");
         metricsMojo.setProjectVersion("99.99");
@@ -51,10 +50,10 @@ public class MetricsMojoIntegrationTest extends AbstractDependencyTrackMojoTest 
 
     @Test
     public void thatWhenMetricsAreNotInProjectTheyAreRetrievedExplicitly() throws Exception {
-        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP)).willReturn(
-                aResponse().withBodyFile("api/v1/project/noMetrics.json")));
-        stubFor(get(urlPathMatching(V1_METRICS_PROJECT_CURRENT)).willReturn(
-                aResponse().withBodyFile("api/v1/metrics/project/project-metrics.json")));
+        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP))
+                .willReturn(aResponse().withBodyFile("api/v1/project/noMetrics.json")));
+        stubFor(get(urlPathMatching(V1_METRICS_PROJECT_CURRENT))
+                .willReturn(aResponse().withBodyFile("api/v1/metrics/project/project-metrics.json")));
 
         metricsMojo.setProjectName("noMetrics");
         metricsMojo.setProjectVersion("1.0.0");
@@ -68,10 +67,10 @@ public class MetricsMojoIntegrationTest extends AbstractDependencyTrackMojoTest 
 
     @Test(expected = MojoExecutionException.class)
     public void thatExceptionIsThrownWhenMetricsCannotBeRetrievedForCurrentProject() throws Exception {
-        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP)).willReturn(
-                aResponse().withBodyFile("api/v1/project/noMetrics.json")));
-        stubFor(get(urlPathMatching(V1_METRICS_PROJECT_CURRENT)).willReturn(
-                aResponse().withFault(Fault.MALFORMED_RESPONSE_CHUNK)));
+        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP))
+                .willReturn(aResponse().withBodyFile("api/v1/project/noMetrics.json")));
+        stubFor(get(urlPathMatching(V1_METRICS_PROJECT_CURRENT))
+                .willReturn(aResponse().withFault(Fault.MALFORMED_RESPONSE_CHUNK)));
 
         metricsMojo.setProjectName("noMetrics");
         metricsMojo.setProjectVersion("1.0.0");
@@ -82,20 +81,19 @@ public class MetricsMojoIntegrationTest extends AbstractDependencyTrackMojoTest 
 
     @Test(expected = MojoFailureException.class)
     public void thatAnyCriticalIssuesPresentCanFailTheBuild() throws Exception {
-        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP)).willReturn(
-                aResponse().withBody(asJson(
-                ProjectBuilder.aProject()
-                    .withUuid("1234")
-                    .withName("test-project")
-                    .withVersion("1.2.3")
-                    .withMetrics(
-                        aMetrics()
-                            .withCritical(101)
-                            .withHigh(201)
-                            .withMedium(301)
-                            .withLow(401)
-                            .withUnassigned(501))
-                        .build()))));
+        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP))
+                .willReturn(aResponse()
+                        .withBody(asJson(ProjectBuilder.aProject()
+                                .withUuid("1234")
+                                .withName("test-project")
+                                .withVersion("1.2.3")
+                                .withMetrics(aMetrics()
+                                        .withCritical(101)
+                                        .withHigh(201)
+                                        .withMedium(301)
+                                        .withLow(401)
+                                        .withUnassigned(501))
+                                .build()))));
 
         metricsMojo.setProjectName("test-project");
         metricsMojo.setProjectVersion("1.2.3");
@@ -107,8 +105,8 @@ public class MetricsMojoIntegrationTest extends AbstractDependencyTrackMojoTest 
 
     @Test
     public void thatTheMetricsIsSkippedWhenSkipIsTrue() throws Exception {
-        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP)).willReturn(
-                aResponse().withBodyFile("api/v1/project/get-all-projects.json")));
+        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP))
+                .willReturn(aResponse().withBodyFile("api/v1/project/get-all-projects.json")));
         metricsMojo.setSkip("true");
         metricsMojo.setProjectName("testName");
         metricsMojo.setProjectVersion("99.99");

--- a/src/test/java/io/github/pmckeown/dependencytrack/metrics/MetricsPrinterTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/metrics/MetricsPrinterTest.java
@@ -1,20 +1,5 @@
 package io.github.pmckeown.dependencytrack.metrics;
 
-import io.github.pmckeown.util.Logger;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
-
-import java.util.Arrays;
-import java.util.Collection;
-
 import static io.github.pmckeown.dependencytrack.Constants.COMPONENTS;
 import static io.github.pmckeown.dependencytrack.Constants.CRITICAL;
 import static io.github.pmckeown.dependencytrack.Constants.FINDINGS_AUDITED;
@@ -35,6 +20,20 @@ import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 
+import io.github.pmckeown.util.Logger;
+import java.util.Arrays;
+import java.util.Collection;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
 @RunWith(Parameterized.class)
 public class MetricsPrinterTest {
 
@@ -47,21 +46,21 @@ public class MetricsPrinterTest {
     @Parameters
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
-                { INHERITED_RISK_SCORE, "1" },
-                { CRITICAL, "100" },
-                { HIGH, "200" },
-                { MEDIUM, "300" },
-                { LOW, "400" },
-                { UNASSIGNED, "500" },
-                { VULNERABILITIES, "600" },
-                { VULNERABLE_COMPONENTS, "700" },
-                { COMPONENTS, "800" },
-                { SUPPRESSED, "900" },
-                { FINDINGS_TOTAL, "1000" },
-                { FINDINGS_AUDITED, "1100" },
-                { FINDINGS_UNAUDITED, "1200" },
-                { FIRST_OCCURRENCE, ISO_OFFSET_DATE_TIME_PATTERN },
-                { LAST_OCCURRENCE, ISO_OFFSET_DATE_TIME_PATTERN }
+            {INHERITED_RISK_SCORE, "1"},
+            {CRITICAL, "100"},
+            {HIGH, "200"},
+            {MEDIUM, "300"},
+            {LOW, "400"},
+            {UNASSIGNED, "500"},
+            {VULNERABILITIES, "600"},
+            {VULNERABLE_COMPONENTS, "700"},
+            {COMPONENTS, "800"},
+            {SUPPRESSED, "900"},
+            {FINDINGS_TOTAL, "1000"},
+            {FINDINGS_AUDITED, "1100"},
+            {FINDINGS_UNAUDITED, "1200"},
+            {FIRST_OCCURRENCE, ISO_OFFSET_DATE_TIME_PATTERN},
+            {LAST_OCCURRENCE, ISO_OFFSET_DATE_TIME_PATTERN}
         });
     }
 
@@ -103,5 +102,4 @@ public class MetricsPrinterTest {
                 .withLastOccurrence(1563445047035L)
                 .build();
     }
-
 }

--- a/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyConditionBuilder.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyConditionBuilder.java
@@ -6,6 +6,7 @@ public class PolicyConditionBuilder {
     private String subject = "Severity";
     private String operator = "==";
     private String value = "IS HIGH";
+
     private PolicyConditionBuilder() {
         // Use builder factory method
     }

--- a/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationBuilder.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationBuilder.java
@@ -1,10 +1,10 @@
 package io.github.pmckeown.dependencytrack.policyviolation;
 
-import io.github.pmckeown.dependencytrack.finding.Component;
-import io.github.pmckeown.dependencytrack.finding.ComponentBuilder;
-
 import static io.github.pmckeown.dependencytrack.finding.ComponentBuilder.aComponent;
 import static io.github.pmckeown.dependencytrack.policyviolation.PolicyConditionBuilder.aPolicyCondition;
+
+import io.github.pmckeown.dependencytrack.finding.Component;
+import io.github.pmckeown.dependencytrack.finding.ComponentBuilder;
 
 public class PolicyViolationBuilder {
 

--- a/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsActionTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsActionTest.java
@@ -1,17 +1,5 @@
 package io.github.pmckeown.dependencytrack.policyviolation;
 
-import io.github.pmckeown.dependencytrack.DependencyTrackException;
-import io.github.pmckeown.dependencytrack.project.Project;
-import io.github.pmckeown.util.Logger;
-import kong.unirest.UnirestException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-
-import java.util.List;
-
 import static io.github.pmckeown.dependencytrack.ResponseBuilder.aNotFoundResponse;
 import static io.github.pmckeown.dependencytrack.ResponseBuilder.aSuccessResponse;
 import static io.github.pmckeown.dependencytrack.finding.ComponentBuilder.aComponent;
@@ -26,6 +14,17 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+
+import io.github.pmckeown.dependencytrack.DependencyTrackException;
+import io.github.pmckeown.dependencytrack.project.Project;
+import io.github.pmckeown.util.Logger;
+import java.util.List;
+import kong.unirest.UnirestException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PolicyViolationsActionTest {
@@ -45,12 +44,13 @@ public class PolicyViolationsActionTest {
         List<PolicyViolation> policyViolations = aListOfPolicyViolations()
                 .withPolicyViolation(aPolicyViolation()
                         .withType("SEVERITY")
-                        .withPolicyCondition(aPolicyCondition()
-                                .withPolicy(new Policy("testPolicy", ViolationState.INFO)))
+                        .withPolicyCondition(
+                                aPolicyCondition().withPolicy(new Policy("testPolicy", ViolationState.INFO)))
                         .withComponent(aComponent()))
                 .build();
         doReturn(aSuccessResponse().withBody(policyViolations).build())
-                .when(policyClient).getPolicyViolationsForProject(project);
+                .when(policyClient)
+                .getPolicyViolationsForProject(project);
 
         List<PolicyViolation> returnedPolicyViolations = policyAction.getPolicyViolations(project);
 

--- a/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsAnalyserTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsAnalyserTest.java
@@ -1,12 +1,5 @@
 package io.github.pmckeown.dependencytrack.policyviolation;
 
-import io.github.pmckeown.util.Logger;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-
 import static io.github.pmckeown.dependencytrack.finding.ComponentBuilder.aComponent;
 import static io.github.pmckeown.dependencytrack.policyviolation.PolicyConditionBuilder.aPolicyCondition;
 import static io.github.pmckeown.dependencytrack.policyviolation.PolicyViolationBuilder.aPolicyViolation;
@@ -17,6 +10,13 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import io.github.pmckeown.util.Logger;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PolicyViolationsAnalyserTest {
@@ -29,12 +29,15 @@ public class PolicyViolationsAnalyserTest {
 
     @Test
     public void thatInfoLevelPolicyViolationsWithFailOnWarnFalseDoesNotResultInPolicyBreach() {
-        boolean isPolicyBreached = policyAnalyser.isAnyPolicyViolationBreached(aListOfPolicyViolations()
-                .withPolicyViolation(aPolicyViolation()
-                        .withType("SEVERITY")
-                        .withPolicyCondition(aPolicyCondition()
-                                .withPolicy(new Policy("Info Severity Policy", ViolationState.INFO)))
-                        .withComponent(aComponent())).build(), false);
+        boolean isPolicyBreached = policyAnalyser.isAnyPolicyViolationBreached(
+                aListOfPolicyViolations()
+                        .withPolicyViolation(aPolicyViolation()
+                                .withType("SEVERITY")
+                                .withPolicyCondition(aPolicyCondition()
+                                        .withPolicy(new Policy("Info Severity Policy", ViolationState.INFO)))
+                                .withComponent(aComponent()))
+                        .build(),
+                false);
         assertFalse(isPolicyBreached);
 
         verify(logger).info(anyString());
@@ -43,12 +46,15 @@ public class PolicyViolationsAnalyserTest {
 
     @Test
     public void thatInfoLevelPolicyViolationsWithFailOnWarnTrueDoesNotResultInPolicyBreach() {
-        boolean isPolicyBreached = policyAnalyser.isAnyPolicyViolationBreached(aListOfPolicyViolations()
-                .withPolicyViolation(aPolicyViolation()
-                        .withType("SEVERITY")
-                        .withPolicyCondition(aPolicyCondition()
-                                .withPolicy(new Policy("Info Severity Policy", ViolationState.INFO)))
-                        .withComponent(aComponent())).build(), true);
+        boolean isPolicyBreached = policyAnalyser.isAnyPolicyViolationBreached(
+                aListOfPolicyViolations()
+                        .withPolicyViolation(aPolicyViolation()
+                                .withType("SEVERITY")
+                                .withPolicyCondition(aPolicyCondition()
+                                        .withPolicy(new Policy("Info Severity Policy", ViolationState.INFO)))
+                                .withComponent(aComponent()))
+                        .build(),
+                true);
         assertFalse(isPolicyBreached);
 
         verify(logger).info(anyString());
@@ -57,12 +63,15 @@ public class PolicyViolationsAnalyserTest {
 
     @Test
     public void thatWarnLevelPolicyViolationsWithFailOnWarnFalseDoesNotResultInPolicyBreach() {
-        boolean isPolicyBreached = policyAnalyser.isAnyPolicyViolationBreached(aListOfPolicyViolations()
-                .withPolicyViolation(aPolicyViolation()
-                        .withType("SEVERITY")
-                        .withPolicyCondition(aPolicyCondition()
-                                .withPolicy(new Policy("Warn Severity Policy", ViolationState.WARN)))
-                        .withComponent(aComponent())).build(), false);
+        boolean isPolicyBreached = policyAnalyser.isAnyPolicyViolationBreached(
+                aListOfPolicyViolations()
+                        .withPolicyViolation(aPolicyViolation()
+                                .withType("SEVERITY")
+                                .withPolicyCondition(aPolicyCondition()
+                                        .withPolicy(new Policy("Warn Severity Policy", ViolationState.WARN)))
+                                .withComponent(aComponent()))
+                        .build(),
+                false);
         assertFalse(isPolicyBreached);
 
         verify(logger).info(anyString());
@@ -71,12 +80,15 @@ public class PolicyViolationsAnalyserTest {
 
     @Test
     public void thatWarnLevelPolicyViolationsWithFailOnWarnTrueDoesResultInPolicyBreach() {
-        boolean isPolicyBreached = policyAnalyser.isAnyPolicyViolationBreached(aListOfPolicyViolations()
-                .withPolicyViolation(aPolicyViolation()
-                        .withType("SEVERITY")
-                        .withPolicyCondition(aPolicyCondition()
-                                .withPolicy(new Policy("Warn Severity Policy", ViolationState.WARN)))
-                        .withComponent(aComponent())).build(), true);
+        boolean isPolicyBreached = policyAnalyser.isAnyPolicyViolationBreached(
+                aListOfPolicyViolations()
+                        .withPolicyViolation(aPolicyViolation()
+                                .withType("SEVERITY")
+                                .withPolicyCondition(aPolicyCondition()
+                                        .withPolicy(new Policy("Warn Severity Policy", ViolationState.WARN)))
+                                .withComponent(aComponent()))
+                        .build(),
+                true);
         assertTrue(isPolicyBreached);
 
         verify(logger).info(anyString());
@@ -85,12 +97,15 @@ public class PolicyViolationsAnalyserTest {
 
     @Test
     public void thatFailLevelPolicyViolationsWithFailOnWarnFalseDoesResultInPolicyBreach() {
-        boolean isPolicyBreached = policyAnalyser.isAnyPolicyViolationBreached(aListOfPolicyViolations()
-                .withPolicyViolation(aPolicyViolation()
-                        .withType("SEVERITY")
-                        .withPolicyCondition(aPolicyCondition()
-                                .withPolicy(new Policy("Fail Severity Policy", ViolationState.FAIL)))
-                        .withComponent(aComponent())).build(), false);
+        boolean isPolicyBreached = policyAnalyser.isAnyPolicyViolationBreached(
+                aListOfPolicyViolations()
+                        .withPolicyViolation(aPolicyViolation()
+                                .withType("SEVERITY")
+                                .withPolicyCondition(aPolicyCondition()
+                                        .withPolicy(new Policy("Fail Severity Policy", ViolationState.FAIL)))
+                                .withComponent(aComponent()))
+                        .build(),
+                false);
         assertTrue(isPolicyBreached);
 
         verify(logger).info(anyString());
@@ -99,12 +114,15 @@ public class PolicyViolationsAnalyserTest {
 
     @Test
     public void thatFailLevelPolicyViolationsWithFailOnWarnTrueDoesResultInPolicyBreach() {
-        boolean isPolicyBreached = policyAnalyser.isAnyPolicyViolationBreached(aListOfPolicyViolations()
-                .withPolicyViolation(aPolicyViolation()
-                        .withType("SEVERITY")
-                        .withPolicyCondition(aPolicyCondition()
-                                .withPolicy(new Policy("Fail Severity Policy", ViolationState.FAIL)))
-                        .withComponent(aComponent())).build(), true);
+        boolean isPolicyBreached = policyAnalyser.isAnyPolicyViolationBreached(
+                aListOfPolicyViolations()
+                        .withPolicyViolation(aPolicyViolation()
+                                .withType("SEVERITY")
+                                .withPolicyCondition(aPolicyCondition()
+                                        .withPolicy(new Policy("Fail Severity Policy", ViolationState.FAIL)))
+                                .withComponent(aComponent()))
+                        .build(),
+                true);
         assertTrue(isPolicyBreached);
 
         verify(logger).info(anyString());

--- a/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsClientTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsClientTest.java
@@ -1,20 +1,5 @@
 package io.github.pmckeown.dependencytrack.policyviolation;
 
-import com.github.tomakehurst.wiremock.http.Fault;
-import io.github.pmckeown.dependencytrack.AbstractDependencyTrackIntegrationTest;
-import io.github.pmckeown.dependencytrack.Response;
-import io.github.pmckeown.util.Logger;
-import kong.unirest.UnirestException;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-
-import java.util.List;
-import java.util.Optional;
-
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.badRequest;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -37,6 +22,20 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
+import com.github.tomakehurst.wiremock.http.Fault;
+import io.github.pmckeown.dependencytrack.AbstractDependencyTrackIntegrationTest;
+import io.github.pmckeown.dependencytrack.Response;
+import io.github.pmckeown.util.Logger;
+import java.util.List;
+import java.util.Optional;
+import kong.unirest.UnirestException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
 @RunWith(MockitoJUnitRunner.class)
 public class PolicyViolationsClientTest extends AbstractDependencyTrackIntegrationTest {
 
@@ -53,17 +52,18 @@ public class PolicyViolationsClientTest extends AbstractDependencyTrackIntegrati
 
     @Test
     public void thatPolicyViolationsCanBeRetrieved() throws Exception {
-        stubFor(get(urlPathMatching(V1_POLICY_VIOLATION_PROJECT_UUID)).willReturn(
-                aResponse().withBody(asJson(
-                        aListOfPolicyViolations()
-                                .withPolicyViolation(
-                                        aPolicyViolation()
-                                                .withType("SEVERITY")
-                                                .withPolicyCondition(aPolicyCondition()
-                                                        .withPolicy(new Policy("testPolicy", ViolationState.INFO)))
-                                                .withComponent(aComponent())).build()))));
+        stubFor(get(urlPathMatching(V1_POLICY_VIOLATION_PROJECT_UUID))
+                .willReturn(aResponse()
+                        .withBody(asJson(aListOfPolicyViolations()
+                                .withPolicyViolation(aPolicyViolation()
+                                        .withType("SEVERITY")
+                                        .withPolicyCondition(aPolicyCondition()
+                                                .withPolicy(new Policy("testPolicy", ViolationState.INFO)))
+                                        .withComponent(aComponent()))
+                                .build()))));
 
-        Response<List<PolicyViolation>> response = policyClient.getPolicyViolationsForProject(aProject().build());
+        Response<List<PolicyViolation>> response =
+                policyClient.getPolicyViolationsForProject(aProject().build());
 
         verify(1, getRequestedFor(urlPathMatching(V1_POLICY_VIOLATION_PROJECT_UUID)));
         assertThat(response.isSuccess(), is(equalTo(true)));
@@ -83,7 +83,8 @@ public class PolicyViolationsClientTest extends AbstractDependencyTrackIntegrati
     public void thatFailureToGetViolationsReturnsAnErrorResponse() {
         stubFor(get(urlPathMatching(V1_POLICY_VIOLATION_PROJECT_UUID)).willReturn(badRequest()));
 
-        Response<List<PolicyViolation>> response = policyClient.getPolicyViolationsForProject(aProject().build());
+        Response<List<PolicyViolation>> response =
+                policyClient.getPolicyViolationsForProject(aProject().build());
 
         verify(1, getRequestedFor(urlPathMatching(V1_POLICY_VIOLATION_PROJECT_UUID)));
         assertThat(response.isSuccess(), is(equalTo(false)));
@@ -92,8 +93,8 @@ public class PolicyViolationsClientTest extends AbstractDependencyTrackIntegrati
 
     @Test
     public void thatAnErrorToGetFindingsThrowsException() {
-        stubFor(get(urlPathMatching(V1_POLICY_VIOLATION_PROJECT_UUID)).willReturn(
-                aResponse().withFault(Fault.RANDOM_DATA_THEN_CLOSE)));
+        stubFor(get(urlPathMatching(V1_POLICY_VIOLATION_PROJECT_UUID))
+                .willReturn(aResponse().withFault(Fault.RANDOM_DATA_THEN_CLOSE)));
 
         try {
             policyClient.getPolicyViolationsForProject(aProject().build());
@@ -102,5 +103,4 @@ public class PolicyViolationsClientTest extends AbstractDependencyTrackIntegrati
             assertThat(ex, is(instanceOf(UnirestException.class)));
         }
     }
-
 }

--- a/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsMojoIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsMojoIntegrationTest.java
@@ -1,18 +1,12 @@
 package io.github.pmckeown.dependencytrack.policyviolation;
 
-import io.github.pmckeown.dependencytrack.AbstractDependencyTrackMojoTest;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
-import org.junit.Before;
-import org.junit.Test;
-
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.github.tomakehurst.wiremock.http.Fault.RANDOM_DATA_THEN_CLOSE;
@@ -23,6 +17,12 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
+
+import io.github.pmckeown.dependencytrack.AbstractDependencyTrackMojoTest;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.junit.Before;
+import org.junit.Test;
 
 public class PolicyViolationsMojoIntegrationTest extends AbstractDependencyTrackMojoTest {
 
@@ -39,10 +39,10 @@ public class PolicyViolationsMojoIntegrationTest extends AbstractDependencyTrack
 
     @Test
     public void thatPolicyMojoCanRetrievePolicyViolationWarningsAndNotFailIfFailOnWarnFalse() throws Exception {
-        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP)).willReturn(
-                aResponse().withBodyFile("api/v1/project/testName-project.json")));
-        stubFor(get(urlMatching(V1_POLICY_VIOLATION_PROJECT_UUID)).willReturn(
-                aResponse().withBodyFile("api/v1/violation/project/policy-violation-warnings.json")));
+        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP))
+                .willReturn(aResponse().withBodyFile("api/v1/project/testName-project.json")));
+        stubFor(get(urlMatching(V1_POLICY_VIOLATION_PROJECT_UUID))
+                .willReturn(aResponse().withBodyFile("api/v1/violation/project/policy-violation-warnings.json")));
         policyMojo.setFailOnWarn(false);
         policyMojo.execute();
 
@@ -51,10 +51,10 @@ public class PolicyViolationsMojoIntegrationTest extends AbstractDependencyTrack
 
     @Test
     public void thatPolicyMojoCanRetrievePolicyViolationWarningsAndFailIfFailOnWarnTrue() {
-        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP)).willReturn(
-                aResponse().withBodyFile("api/v1/project/testName-project.json")));
-        stubFor(get(urlMatching(V1_POLICY_VIOLATION_PROJECT_UUID)).willReturn(
-                aResponse().withBodyFile("api/v1/violation/project/policy-violation-warnings.json")));
+        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP))
+                .willReturn(aResponse().withBodyFile("api/v1/project/testName-project.json")));
+        stubFor(get(urlMatching(V1_POLICY_VIOLATION_PROJECT_UUID))
+                .willReturn(aResponse().withBodyFile("api/v1/violation/project/policy-violation-warnings.json")));
         policyMojo.setFailOnWarn(true);
 
         try {
@@ -69,10 +69,10 @@ public class PolicyViolationsMojoIntegrationTest extends AbstractDependencyTrack
 
     @Test
     public void thatPolicyMojoCanRetrievePolicyViolationFailuresAndFailIfFailOnWarnFalse() {
-        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP)).willReturn(
-                aResponse().withBodyFile("api/v1/project/testName-project.json")));
-        stubFor(get(urlMatching(V1_POLICY_VIOLATION_PROJECT_UUID)).willReturn(
-                aResponse().withBodyFile("api/v1/violation/project/policy-violation-failures.json")));
+        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP))
+                .willReturn(aResponse().withBodyFile("api/v1/project/testName-project.json")));
+        stubFor(get(urlMatching(V1_POLICY_VIOLATION_PROJECT_UUID))
+                .willReturn(aResponse().withBodyFile("api/v1/violation/project/policy-violation-failures.json")));
         policyMojo.setFailOnWarn(false);
 
         try {
@@ -87,10 +87,10 @@ public class PolicyViolationsMojoIntegrationTest extends AbstractDependencyTrack
 
     @Test
     public void thatPolicyMojoCanRetrievePolicyViolationFailuresAndFailIfFailOnWarnTrue() {
-        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP)).willReturn(
-                aResponse().withBodyFile("api/v1/project/testName-project.json")));
-        stubFor(get(urlMatching(V1_POLICY_VIOLATION_PROJECT_UUID)).willReturn(
-                aResponse().withBodyFile("api/v1/violation/project/policy-violation-failures.json")));
+        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP))
+                .willReturn(aResponse().withBodyFile("api/v1/project/testName-project.json")));
+        stubFor(get(urlMatching(V1_POLICY_VIOLATION_PROJECT_UUID))
+                .willReturn(aResponse().withBodyFile("api/v1/violation/project/policy-violation-failures.json")));
         policyMojo.setFailOnWarn(true);
 
         try {
@@ -105,8 +105,8 @@ public class PolicyViolationsMojoIntegrationTest extends AbstractDependencyTrack
 
     @Test
     public void thatWhenExceptionOccursWhileGettingFindingsAndFailOnErrorIsTrueTheMojoErrors() throws Exception {
-        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP)).willReturn(
-                aResponse().withBodyFile("api/v1/project/testName-project.json")));
+        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP))
+                .willReturn(aResponse().withBodyFile("api/v1/project/testName-project.json")));
         stubFor(get(urlPathMatching(V1_POLICY_VIOLATION_PROJECT_UUID))
                 .willReturn(aResponse().withFault(RANDOM_DATA_THEN_CLOSE)));
 
@@ -122,8 +122,8 @@ public class PolicyViolationsMojoIntegrationTest extends AbstractDependencyTrack
 
     @Test
     public void thatWhenExceptionOccursWhileGettingFindingsAndFailOnErrorIsFalseTheMojoSucceeds() throws Exception {
-        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP)).willReturn(
-                aResponse().withBodyFile("api/v1/project/testName-project.json")));
+        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP))
+                .willReturn(aResponse().withBodyFile("api/v1/project/testName-project.json")));
         stubFor(get(urlPathMatching(V1_POLICY_VIOLATION_PROJECT_UUID))
                 .willReturn(aResponse().withFault(RANDOM_DATA_THEN_CLOSE)));
 

--- a/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsMojoTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsMojoTest.java
@@ -1,19 +1,18 @@
 package io.github.pmckeown.dependencytrack.policyviolation;
 
+import static org.mockito.Mockito.*;
+
 import io.github.pmckeown.dependencytrack.CommonConfig;
 import io.github.pmckeown.dependencytrack.ModuleConfig;
 import io.github.pmckeown.dependencytrack.policyviolation.report.PolicyViolationsReportGenerator;
 import io.github.pmckeown.dependencytrack.project.ProjectAction;
 import io.github.pmckeown.util.Logger;
+import java.util.ArrayList;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import java.util.ArrayList;
-
-import static org.mockito.Mockito.*;
 
 @SuppressWarnings("unused")
 @RunWith(MockitoJUnitRunner.class)
@@ -50,8 +49,7 @@ public class PolicyViolationsMojoTest {
     public void thatReportIsAlwaysGeneratedEvenWhenNoFindingsArePresent() throws Exception {
         policyMojo.performAction();
 
-        verify(policyViolationReportGenerator, times(1)).generate(
-                null, new ArrayList<>());
+        verify(policyViolationReportGenerator, times(1)).generate(null, new ArrayList<>());
     }
 
     @Test
@@ -62,5 +60,4 @@ public class PolicyViolationsMojoTest {
 
         verifyNoInteractions(policyViolationReportGenerator);
     }
-
 }

--- a/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsPrinterTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsPrinterTest.java
@@ -1,15 +1,5 @@
 package io.github.pmckeown.dependencytrack.policyviolation;
 
-import io.github.pmckeown.dependencytrack.project.Project;
-import io.github.pmckeown.util.Logger;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-
-import java.util.List;
-
 import static io.github.pmckeown.dependencytrack.Constants.DELIMITER;
 import static io.github.pmckeown.dependencytrack.finding.ComponentBuilder.aComponent;
 import static io.github.pmckeown.dependencytrack.policyviolation.PolicyConditionBuilder.aPolicyCondition;
@@ -18,6 +8,15 @@ import static io.github.pmckeown.dependencytrack.policyviolation.PolicyViolation
 import static io.github.pmckeown.dependencytrack.project.ProjectBuilder.aProject;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+
+import io.github.pmckeown.dependencytrack.project.Project;
+import io.github.pmckeown.util.Logger;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PolicyViolationsPrinterTest {
@@ -53,10 +52,12 @@ public class PolicyViolationsPrinterTest {
     @Test
     public void thatMultiplePolicyViolationsArePrintedCorrectly() {
         Project project = aProject().withName("a").withVersion("1").build();
-        policyViolationsPrinter.printPolicyViolations(project, aListOfPolicyViolations()
-                .withPolicyViolation(policyViolation("SEVERITY", "p1", ViolationState.INFO))
-                .withPolicyViolation(policyViolation("SEVERITY", "p2", ViolationState.WARN))
-                .build());
+        policyViolationsPrinter.printPolicyViolations(
+                project,
+                aListOfPolicyViolations()
+                        .withPolicyViolation(policyViolation("SEVERITY", "p1", ViolationState.INFO))
+                        .withPolicyViolation(policyViolation("SEVERITY", "p2", ViolationState.WARN))
+                        .build());
 
         verify(logger, times(3)).info(DELIMITER);
         verify(logger).info("%d policy violation(s) were retrieved for project: %s", 2, "a");
@@ -65,13 +66,12 @@ public class PolicyViolationsPrinterTest {
         verify(logger).info("Policy name: %s (%s)", "p2", "WARN");
     }
 
-    private List<PolicyViolation> policyViolationsList(String riskType, String policyName,
-            ViolationState violationState) {
+    private List<PolicyViolation> policyViolationsList(
+            String riskType, String policyName, ViolationState violationState) {
         return aListOfPolicyViolations()
                 .withPolicyViolation(aPolicyViolation()
                         .withType(riskType)
-                        .withPolicyCondition(aPolicyCondition()
-                                .withPolicy(new Policy(policyName, violationState)))
+                        .withPolicyCondition(aPolicyCondition().withPolicy(new Policy(policyName, violationState)))
                         .withComponent(aComponent()))
                 .build();
     }
@@ -79,8 +79,7 @@ public class PolicyViolationsPrinterTest {
     private PolicyViolationBuilder policyViolation(String riskType, String policyName, ViolationState violationState) {
         return aPolicyViolation()
                 .withType(riskType)
-                .withPolicyCondition(aPolicyCondition()
-                    .withPolicy(new Policy(policyName, violationState)))
+                .withPolicyCondition(aPolicyCondition().withPolicy(new Policy(policyName, violationState)))
                 .withComponent(aComponent());
     }
 }

--- a/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/report/PolicyViolationsReportGeneratorTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/report/PolicyViolationsReportGeneratorTest.java
@@ -1,17 +1,5 @@
 package io.github.pmckeown.dependencytrack.policyviolation.report;
 
-import io.github.pmckeown.dependencytrack.DependencyTrackException;
-import io.github.pmckeown.dependencytrack.policyviolation.PolicyViolation;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-
-import java.util.ArrayList;
-import java.util.List;
-
 import static io.github.pmckeown.dependencytrack.policyviolation.PolicyViolationListBuilder.aListOfPolicyViolations;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -22,6 +10,17 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+
+import io.github.pmckeown.dependencytrack.DependencyTrackException;
+import io.github.pmckeown.dependencytrack.policyviolation.PolicyViolation;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PolicyViolationsReportGeneratorTest {
@@ -48,7 +47,9 @@ public class PolicyViolationsReportGeneratorTest {
     @Test
     public void thatExceptionWhenWritingXmlReportIsHandledAndHtmlIsNotAttempted() throws Exception {
 
-        doThrow(DependencyTrackException.class).when(xmlReportWriter).write(isNull(), any(PolicyViolationsReport.class));
+        doThrow(DependencyTrackException.class)
+                .when(xmlReportWriter)
+                .write(isNull(), any(PolicyViolationsReport.class));
 
         try {
             policyViolationReportGenerator.generate(null, new ArrayList<>());

--- a/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/report/PolicyViolationsReportIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/report/PolicyViolationsReportIntegrationTest.java
@@ -1,16 +1,5 @@
 package io.github.pmckeown.dependencytrack.policyviolation.report;
 
-import io.github.pmckeown.dependencytrack.policyviolation.Policy;
-import io.github.pmckeown.dependencytrack.policyviolation.PolicyViolation;
-import io.github.pmckeown.dependencytrack.policyviolation.ViolationState;
-import io.github.pmckeown.dependencytrack.report.TransformerFactoryProvider;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-
-import java.io.File;
-import java.util.List;
-
 import static io.github.pmckeown.dependencytrack.finding.ComponentBuilder.aComponent;
 import static io.github.pmckeown.dependencytrack.policyviolation.PolicyConditionBuilder.aPolicyCondition;
 import static io.github.pmckeown.dependencytrack.policyviolation.PolicyViolationBuilder.aPolicyViolation;
@@ -18,6 +7,16 @@ import static io.github.pmckeown.dependencytrack.policyviolation.PolicyViolation
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
+
+import io.github.pmckeown.dependencytrack.policyviolation.Policy;
+import io.github.pmckeown.dependencytrack.policyviolation.PolicyViolation;
+import io.github.pmckeown.dependencytrack.policyviolation.ViolationState;
+import io.github.pmckeown.dependencytrack.report.TransformerFactoryProvider;
+import java.io.File;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
 
 public class PolicyViolationsReportIntegrationTest {
 
@@ -37,8 +36,8 @@ public class PolicyViolationsReportIntegrationTest {
         try {
             File outputDirectory = new File("target");
             xmlReportWriter.write(outputDirectory, new PolicyViolationsReport(policyViolations()));
-            assertThat(new File(outputDirectory, PolicyViolationsReportConstants.XML_REPORT_FILENAME).exists(),
-                    is(true));
+            assertThat(
+                    new File(outputDirectory, PolicyViolationsReportConstants.XML_REPORT_FILENAME).exists(), is(true));
         } catch (Exception ex) {
             fail("Exception not expected");
         }
@@ -51,8 +50,8 @@ public class PolicyViolationsReportIntegrationTest {
             File outputDirectory = new File("target");
             xmlReportWriter.write(outputDirectory, new PolicyViolationsReport(policyViolations()));
             htmlReportWriter.write(outputDirectory);
-            assertThat(new File(outputDirectory, PolicyViolationsReportConstants.HTML_REPORT_FILENAME).exists(),
-                    is(true));
+            assertThat(
+                    new File(outputDirectory, PolicyViolationsReportConstants.HTML_REPORT_FILENAME).exists(), is(true));
         } catch (Exception ex) {
             ex.printStackTrace();
             fail("Exception not expected");
@@ -63,10 +62,10 @@ public class PolicyViolationsReportIntegrationTest {
         List<PolicyViolation> policyViolations = aListOfPolicyViolations()
                 .withPolicyViolation(aPolicyViolation()
                         .withType("SEVERITY")
-                        .withPolicyCondition(aPolicyCondition()
-                                .withPolicy(new Policy("testPolicy1", ViolationState.INFO)))
-                        .withComponent(aComponent())).build();
+                        .withPolicyCondition(
+                                aPolicyCondition().withPolicy(new Policy("testPolicy1", ViolationState.INFO)))
+                        .withComponent(aComponent()))
+                .build();
         return policyViolations;
     }
-
 }

--- a/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/report/PolicyViolationsReportTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/report/PolicyViolationsReportTest.java
@@ -1,9 +1,5 @@
 package io.github.pmckeown.dependencytrack.policyviolation.report;
 
-import io.github.pmckeown.dependencytrack.policyviolation.Policy;
-import io.github.pmckeown.dependencytrack.policyviolation.ViolationState;
-import org.junit.Test;
-
 import static io.github.pmckeown.dependencytrack.finding.ComponentBuilder.aComponent;
 import static io.github.pmckeown.dependencytrack.policyviolation.PolicyConditionBuilder.aPolicyCondition;
 import static io.github.pmckeown.dependencytrack.policyviolation.PolicyViolationBuilder.aPolicyViolation;
@@ -12,6 +8,10 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import io.github.pmckeown.dependencytrack.policyviolation.Policy;
+import io.github.pmckeown.dependencytrack.policyviolation.ViolationState;
+import org.junit.Test;
+
 public class PolicyViolationsReportTest {
 
     @Test
@@ -19,19 +19,25 @@ public class PolicyViolationsReportTest {
         PolicyViolationsReport policyViolationReport = new PolicyViolationsReport(aListOfPolicyViolations()
                 .withPolicyViolation(aPolicyViolation()
                         .withType("SEVERITY")
-                        .withPolicyCondition(aPolicyCondition()
-                                .withPolicy(new Policy("Info Policy", ViolationState.INFO)))
+                        .withPolicyCondition(
+                                aPolicyCondition().withPolicy(new Policy("Info Policy", ViolationState.INFO)))
                         .withComponent(aComponent()))
                 .withPolicyViolation(aPolicyViolation()
                         .withType("LICENSE")
-                        .withPolicyCondition(aPolicyCondition()
-                                .withPolicy(new Policy("Warn Policy", ViolationState.WARN)))
-                        .withComponent(aComponent())).build());
+                        .withPolicyCondition(
+                                aPolicyCondition().withPolicy(new Policy("Warn Policy", ViolationState.WARN)))
+                        .withComponent(aComponent()))
+                .build());
 
         assertThat(policyViolationReport.getPolicyViolations().getCount(), is(equalTo(2)));
-        assertThat(policyViolationReport.getPolicyViolations().getPolicyViolations()
-                        .get(0).getPolicyCondition().getPolicy().getName(),
+        assertThat(
+                policyViolationReport
+                        .getPolicyViolations()
+                        .getPolicyViolations()
+                        .get(0)
+                        .getPolicyCondition()
+                        .getPolicy()
+                        .getName(),
                 is(equalTo("Info Policy")));
     }
-
 }

--- a/src/test/java/io/github/pmckeown/dependencytrack/project/DeleteProjectActionTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/project/DeleteProjectActionTest.java
@@ -1,17 +1,8 @@
 package io.github.pmckeown.dependencytrack.project;
 
-import io.github.pmckeown.dependencytrack.DependencyTrackException;
-import io.github.pmckeown.util.Logger;
-import kong.unirest.UnirestException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-
-import static io.github.pmckeown.dependencytrack.project.ProjectBuilder.aProject;
 import static io.github.pmckeown.dependencytrack.ResponseBuilder.aNotFoundResponse;
 import static io.github.pmckeown.dependencytrack.ResponseBuilder.aSuccessResponse;
+import static io.github.pmckeown.dependencytrack.project.ProjectBuilder.aProject;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -22,6 +13,15 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
+
+import io.github.pmckeown.dependencytrack.DependencyTrackException;
+import io.github.pmckeown.util.Logger;
+import kong.unirest.UnirestException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DeleteProjectActionTest {
@@ -65,5 +65,4 @@ public class DeleteProjectActionTest {
 
         verify(logger, atLeastOnce()).error(anyString(), any(UnirestException.class));
     }
-
 }

--- a/src/test/java/io/github/pmckeown/dependencytrack/project/DeleteProjectMojoIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/project/DeleteProjectMojoIntegrationTest.java
@@ -1,20 +1,13 @@
 package io.github.pmckeown.dependencytrack.project;
 
-import com.github.tomakehurst.wiremock.http.Fault;
-import io.github.pmckeown.dependencytrack.AbstractDependencyTrackMojoTest;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
-import org.junit.Before;
-import org.junit.Test;
-
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.delete;
 import static com.github.tomakehurst.wiremock.client.WireMock.deleteRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static io.github.pmckeown.TestMojoLoader.loadDeleteProjectMojo;
 import static io.github.pmckeown.dependencytrack.ResourceConstants.V1_PROJECT_LOOKUP;
@@ -23,6 +16,13 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
+
+import com.github.tomakehurst.wiremock.http.Fault;
+import io.github.pmckeown.dependencytrack.AbstractDependencyTrackMojoTest;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.junit.Before;
+import org.junit.Test;
 
 public class DeleteProjectMojoIntegrationTest extends AbstractDependencyTrackMojoTest {
 
@@ -39,10 +39,9 @@ public class DeleteProjectMojoIntegrationTest extends AbstractDependencyTrackMoj
 
     @Test
     public void thatAProjectCanBeDeleted() throws Exception {
-        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP)).willReturn(
-                aResponse().withBodyFile("api/v1/project/dependency-track-3.6.json")));
-        stubFor(delete(urlPathMatching(V1_PROJECT_UUID)).willReturn(
-                aResponse().withStatus(200)));
+        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP))
+                .willReturn(aResponse().withBodyFile("api/v1/project/dependency-track-3.6.json")));
+        stubFor(delete(urlPathMatching(V1_PROJECT_UUID)).willReturn(aResponse().withStatus(200)));
 
         deleteProjectMojo.execute();
 
@@ -51,10 +50,9 @@ public class DeleteProjectMojoIntegrationTest extends AbstractDependencyTrackMoj
 
     @Test
     public void thatWhenProjectDeletionFailedAndFailOnErrorFalseThenMojoSucceeds() {
-        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP)).willReturn(
-                aResponse().withBodyFile("api/v1/project/dependency-track-3.6.json")));
-        stubFor(delete(urlPathMatching(V1_PROJECT_UUID)).willReturn(
-                aResponse().withStatus(500)));
+        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP))
+                .willReturn(aResponse().withBodyFile("api/v1/project/dependency-track-3.6.json")));
+        stubFor(delete(urlPathMatching(V1_PROJECT_UUID)).willReturn(aResponse().withStatus(500)));
 
         deleteProjectMojo.setFailOnError(false);
 
@@ -66,11 +64,11 @@ public class DeleteProjectMojoIntegrationTest extends AbstractDependencyTrackMoj
     }
 
     @Test(expected = MojoFailureException.class)
-    public void thatWhenProjectDeletionFailedAndFailOnErrorTrueThenMojoFailureExceptionIsThrown() throws MojoExecutionException, MojoFailureException {
-        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP)).willReturn(
-                aResponse().withBodyFile("api/v1/project/testName-project.json")));
-        stubFor(delete(urlPathMatching(V1_PROJECT_UUID)).willReturn(
-                aResponse().withStatus(500)));
+    public void thatWhenProjectDeletionFailedAndFailOnErrorTrueThenMojoFailureExceptionIsThrown()
+            throws MojoExecutionException, MojoFailureException {
+        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP))
+                .willReturn(aResponse().withBodyFile("api/v1/project/testName-project.json")));
+        stubFor(delete(urlPathMatching(V1_PROJECT_UUID)).willReturn(aResponse().withStatus(500)));
 
         deleteProjectMojo.setFailOnError(true);
 
@@ -94,10 +92,10 @@ public class DeleteProjectMojoIntegrationTest extends AbstractDependencyTrackMoj
 
     @Test
     public void thatWhenProjectDeleteErrorsAndFailOnErrorTrueThenMojoExecutionExceptionIsThrown() {
-        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP)).willReturn(
-                aResponse().withBodyFile("api/v1/project/testName-project.json")));
-        stubFor(delete(urlPathMatching(V1_PROJECT_UUID)).willReturn(
-                aResponse().withFault(Fault.RANDOM_DATA_THEN_CLOSE)));
+        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP))
+                .willReturn(aResponse().withBodyFile("api/v1/project/testName-project.json")));
+        stubFor(delete(urlPathMatching(V1_PROJECT_UUID))
+                .willReturn(aResponse().withFault(Fault.RANDOM_DATA_THEN_CLOSE)));
 
         deleteProjectMojo.setFailOnError(true);
 
@@ -110,10 +108,10 @@ public class DeleteProjectMojoIntegrationTest extends AbstractDependencyTrackMoj
 
     @Test
     public void thatWhenProjectDeleteErrorsAndFailOnErrorFalseThenMojoSucceeds() {
-        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP)).willReturn(
-                aResponse().withBodyFile("api/v1/project/testName-project.json")));
-        stubFor(delete(urlPathMatching(V1_PROJECT_UUID)).willReturn(
-                aResponse().withFault(Fault.RANDOM_DATA_THEN_CLOSE)));
+        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP))
+                .willReturn(aResponse().withBodyFile("api/v1/project/testName-project.json")));
+        stubFor(delete(urlPathMatching(V1_PROJECT_UUID))
+                .willReturn(aResponse().withFault(Fault.RANDOM_DATA_THEN_CLOSE)));
 
         deleteProjectMojo.setFailOnError(false);
 
@@ -126,10 +124,9 @@ public class DeleteProjectMojoIntegrationTest extends AbstractDependencyTrackMoj
 
     @Test
     public void thatDeleteIsSkippedWhenSkipIsTrue() throws Exception {
-        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP)).willReturn(
-                aResponse().withBodyFile("api/v1/project/testName-project.json")));
-        stubFor(delete(urlPathMatching(V1_PROJECT_UUID)).willReturn(
-                aResponse().withStatus(200)));
+        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP))
+                .willReturn(aResponse().withBodyFile("api/v1/project/testName-project.json")));
+        stubFor(delete(urlPathMatching(V1_PROJECT_UUID)).willReturn(aResponse().withStatus(200)));
 
         deleteProjectMojo.setSkip("true");
 

--- a/src/test/java/io/github/pmckeown/dependencytrack/project/ProjectActionTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/project/ProjectActionTest.java
@@ -1,21 +1,5 @@
 package io.github.pmckeown.dependencytrack.project;
 
-import io.github.pmckeown.dependencytrack.CommonConfig;
-import io.github.pmckeown.dependencytrack.DependencyTrackException;
-import io.github.pmckeown.dependencytrack.ModuleConfig;
-import io.github.pmckeown.dependencytrack.Response;
-import io.github.pmckeown.dependencytrack.bom.BomParser;
-import io.github.pmckeown.util.Logger;
-import kong.unirest.UnirestException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-
-import java.io.File;
-import java.util.*;
-
 import static io.github.pmckeown.dependencytrack.ResponseBuilder.aSuccessResponse;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -24,6 +8,21 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+
+import io.github.pmckeown.dependencytrack.CommonConfig;
+import io.github.pmckeown.dependencytrack.DependencyTrackException;
+import io.github.pmckeown.dependencytrack.ModuleConfig;
+import io.github.pmckeown.dependencytrack.Response;
+import io.github.pmckeown.dependencytrack.bom.BomParser;
+import io.github.pmckeown.util.Logger;
+import java.io.File;
+import java.util.*;
+import kong.unirest.UnirestException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ProjectActionTest {
@@ -49,7 +48,9 @@ public class ProjectActionTest {
 
     @Test
     public void thatProjectCanBeRetrievedByCommonConfig() throws Exception {
-        doReturn(aSuccessResponse().withBody(project2()).build()).when(projectClient).getProject(anyString(), anyString(), anyString());
+        doReturn(aSuccessResponse().withBody(project2()).build())
+                .when(projectClient)
+                .getProject(anyString(), anyString(), anyString());
 
         Project project = projectAction.getProject(getModuleConfig());
 
@@ -59,7 +60,9 @@ public class ProjectActionTest {
 
     @Test
     public void thatProjectCanBeRetrievedByNameAndVersion() throws Exception {
-        doReturn(aSuccessResponse().withBody(project2()).build()).when(projectClient).getProject(anyString(), anyString(), anyString());
+        doReturn(aSuccessResponse().withBody(project2()).build())
+                .when(projectClient)
+                .getProject(anyString(), anyString(), anyString());
 
         Project project = projectAction.getProject(PROJECT_NAME_2, PROJECT_VERSION_2);
 
@@ -69,7 +72,9 @@ public class ProjectActionTest {
 
     @Test
     public void thatProjectCanBeRetrievedByUuid() throws Exception {
-        doReturn(aSuccessResponse().withBody(project2()).build()).when(projectClient).getProject(anyString(), anyString(), anyString());
+        doReturn(aSuccessResponse().withBody(project2()).build())
+                .when(projectClient)
+                .getProject(anyString(), anyString(), anyString());
 
         Project project = projectAction.getProject(UUID_2);
 
@@ -119,7 +124,8 @@ public class ProjectActionTest {
         doReturn(aSuccessResponse().build()).when(projectClient).patchProject(anyString(), any(ProjectInfo.class));
 
         UpdateRequest updateReq = new UpdateRequest();
-        updateReq.withBomLocation(String.valueOf(new File(BomParser.class.getResource("bom.xml").getPath())));
+        updateReq.withBomLocation(
+                String.valueOf(new File(BomParser.class.getResource("bom.xml").getPath())));
         boolean projectInfoUpdated = projectAction.updateProject(project1(), updateReq);
         assertThat(projectInfoUpdated, is(equalTo(true)));
     }
@@ -130,7 +136,8 @@ public class ProjectActionTest {
         doReturn(aNotFoundResponse()).when(projectClient).patchProject(anyString(), any(ProjectInfo.class));
 
         UpdateRequest updateReq = new UpdateRequest();
-        updateReq.withBomLocation(String.valueOf(new File(BomParser.class.getResource("bom.xml").getPath())));
+        updateReq.withBomLocation(
+                String.valueOf(new File(BomParser.class.getResource("bom.xml").getPath())));
         boolean projectInfoUpdated = projectAction.updateProject(project1(), updateReq);
         assertThat(projectInfoUpdated, is(equalTo(false)));
     }
@@ -141,7 +148,8 @@ public class ProjectActionTest {
         doThrow(UnirestException.class).when(projectClient).patchProject(anyString(), any(ProjectInfo.class));
         try {
             UpdateRequest updateReq = new UpdateRequest();
-            updateReq.withBomLocation(String.valueOf(new File(BomParser.class.getResource("bom.xml").getPath())));
+            updateReq.withBomLocation(String.valueOf(
+                    new File(BomParser.class.getResource("bom.xml").getPath())));
             projectAction.updateProject(project1(), updateReq);
             fail("Exception expected");
         } catch (Exception ex) {
@@ -183,7 +191,8 @@ public class ProjectActionTest {
         doReturn(aSuccessResponse().build()).when(projectClient).patchProject(anyString(), any(ProjectInfo.class));
 
         UpdateRequest updateReq = new UpdateRequest();
-        updateReq.withBomLocation(String.valueOf(new File(BomParser.class.getResource("bom.xml").getPath())));
+        updateReq.withBomLocation(
+                String.valueOf(new File(BomParser.class.getResource("bom.xml").getPath())));
         assertTrue(projectAction.updateProject(project3(), updateReq));
     }
 
@@ -193,7 +202,8 @@ public class ProjectActionTest {
         doReturn(aSuccessResponse().build()).when(projectClient).patchProject(anyString(), any(ProjectInfo.class));
 
         UpdateRequest updateReq = new UpdateRequest();
-        updateReq.withBomLocation(String.valueOf(new File(BomParser.class.getResource("bom.xml").getPath())));
+        updateReq.withBomLocation(
+                String.valueOf(new File(BomParser.class.getResource("bom.xml").getPath())));
         assertTrue(projectAction.updateProject(project1(), updateReq));
     }
 

--- a/src/test/java/io/github/pmckeown/dependencytrack/project/ProjectBuilder.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/project/ProjectBuilder.java
@@ -2,7 +2,6 @@ package io.github.pmckeown.dependencytrack.project;
 
 import io.github.pmckeown.dependencytrack.metrics.Metrics;
 import io.github.pmckeown.dependencytrack.metrics.MetricsBuilder;
-
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;

--- a/src/test/java/io/github/pmckeown/dependencytrack/project/ProjectClientIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/project/ProjectClientIntegrationTest.java
@@ -1,5 +1,14 @@
 package io.github.pmckeown.dependencytrack.project;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static io.github.pmckeown.dependencytrack.ResourceConstants.V1_PROJECT_LOOKUP;
+import static io.github.pmckeown.dependencytrack.TestResourceConstants.V1_PROJECT_UUID;
+import static io.github.pmckeown.dependencytrack.project.ProjectInfoBuilder.aProjectInfo;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.doReturn;
+
 import io.github.pmckeown.dependencytrack.AbstractDependencyTrackMojoTest;
 import io.github.pmckeown.dependencytrack.CommonConfig;
 import io.github.pmckeown.dependencytrack.ModuleConfig;
@@ -11,15 +20,6 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static io.github.pmckeown.dependencytrack.ResourceConstants.V1_PROJECT_LOOKUP;
-import static io.github.pmckeown.dependencytrack.TestResourceConstants.V1_PROJECT_UUID;
-import static io.github.pmckeown.dependencytrack.project.ProjectInfoBuilder.aProjectInfo;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.doReturn;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ProjectClientIntegrationTest extends AbstractDependencyTrackMojoTest {
@@ -41,10 +41,10 @@ public class ProjectClientIntegrationTest extends AbstractDependencyTrackMojoTes
 
     @Test
     public void thatProjectInfoUpdateReturnsSuccessWhenServerReturnsSuccess() {
-        stubFor(patch(urlPathMatching(V1_PROJECT_UUID)).willReturn(
-                aResponse().withStatus(HttpStatus.OK)));
+        stubFor(patch(urlPathMatching(V1_PROJECT_UUID)).willReturn(aResponse().withStatus(HttpStatus.OK)));
 
-        Response<Void> response = projectClient.patchProject("3b2fa278-6380-4430-b646-a353107e9fbe", aProjectInfo().build());
+        Response<Void> response = projectClient.patchProject(
+                "3b2fa278-6380-4430-b646-a353107e9fbe", aProjectInfo().build());
         assertThat(response.isSuccess(), is(equalTo(true)));
         verify(exactly(1), patchRequestedFor(urlPathMatching(V1_PROJECT_UUID)));
     }
@@ -53,12 +53,11 @@ public class ProjectClientIntegrationTest extends AbstractDependencyTrackMojoTes
     public void thatProjectParsingWorks() {
         doReturn("doesn't matter").when(moduleConfig).getProjectName();
         doReturn("doesn't matter").when(moduleConfig).getProjectVersion();
-        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP)).willReturn(
-                aResponse()
-                        .withStatus(HttpStatus.OK)
-                        .withBodyFile("api/v1/project/tags-project.json")));
+        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP))
+                .willReturn(aResponse().withStatus(HttpStatus.OK).withBodyFile("api/v1/project/tags-project.json")));
 
-        Response<Project> response = projectClient.getProject(moduleConfig.getProjectUuid(), moduleConfig.getProjectName(), moduleConfig.getProjectVersion());
+        Response<Project> response = projectClient.getProject(
+                moduleConfig.getProjectUuid(), moduleConfig.getProjectName(), moduleConfig.getProjectVersion());
         assertThat(response.isSuccess(), is(equalTo(true)));
         assertThat(response.getBody().isPresent(), is(equalTo(true)));
         Project project = response.getBody().get();
@@ -72,20 +71,20 @@ public class ProjectClientIntegrationTest extends AbstractDependencyTrackMojoTes
 
     @Test
     public void thatProjectInfoUpdateReturnsSuccessWhenServerReturnsNotModified() {
-        stubFor(patch(urlPathMatching(V1_PROJECT_UUID)).willReturn(
-                aResponse().withStatus(HttpStatus.NOT_MODIFIED)));
+        stubFor(patch(urlPathMatching(V1_PROJECT_UUID)).willReturn(aResponse().withStatus(HttpStatus.NOT_MODIFIED)));
 
-        Response<Void> response = projectClient.patchProject("3b2fa278-6380-4430-b646-a353107e9fbe", aProjectInfo().build());
+        Response<Void> response = projectClient.patchProject(
+                "3b2fa278-6380-4430-b646-a353107e9fbe", aProjectInfo().build());
         assertThat(response.isSuccess(), is(equalTo(true)));
         verify(exactly(1), patchRequestedFor(urlPathMatching(V1_PROJECT_UUID)));
     }
 
     @Test
     public void thatProjectInfoUpdateReturnsFailedWhenServerReturnsTeapot() {
-        stubFor(patch(urlPathMatching(V1_PROJECT_UUID)).willReturn(
-                aResponse().withStatus(HttpStatus.IM_A_TEAPOT)));
+        stubFor(patch(urlPathMatching(V1_PROJECT_UUID)).willReturn(aResponse().withStatus(HttpStatus.IM_A_TEAPOT)));
 
-        Response<Void> response = projectClient.patchProject("3b2fa278-6380-4430-b646-a353107e9fbe", aProjectInfo().build());
+        Response<Void> response = projectClient.patchProject(
+                "3b2fa278-6380-4430-b646-a353107e9fbe", aProjectInfo().build());
         assertThat(response.isSuccess(), is(equalTo(false)));
         verify(exactly(1), patchRequestedFor(urlPathMatching(V1_PROJECT_UUID)));
     }

--- a/src/test/java/io/github/pmckeown/dependencytrack/project/ProjectInfoBuilder.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/project/ProjectInfoBuilder.java
@@ -3,7 +3,7 @@ package io.github.pmckeown.dependencytrack.project;
 /**
  * Builder class for thr {@link ProjectInfo} object.
  *
- * Currently only supports the Group property.
+ * <p>Currently only supports the Group property.
  */
 public class ProjectInfoBuilder {
 

--- a/src/test/java/io/github/pmckeown/dependencytrack/score/ScoreActionTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/score/ScoreActionTest.java
@@ -1,5 +1,16 @@
 package io.github.pmckeown.dependencytrack.score;
 
+import static io.github.pmckeown.dependencytrack.ResponseBuilder.aSuccessResponse;
+import static io.github.pmckeown.dependencytrack.metrics.MetricsBuilder.aMetrics;
+import static io.github.pmckeown.dependencytrack.project.ProjectBuilder.aProject;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
 import io.github.pmckeown.dependencytrack.DependencyTrackException;
 import io.github.pmckeown.dependencytrack.ModuleConfig;
 import io.github.pmckeown.dependencytrack.Response;
@@ -13,17 +24,6 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import static io.github.pmckeown.dependencytrack.ResponseBuilder.aSuccessResponse;
-import static io.github.pmckeown.dependencytrack.metrics.MetricsBuilder.aMetrics;
-import static io.github.pmckeown.dependencytrack.project.ProjectBuilder.aProject;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ScoreActionTest {
@@ -52,7 +52,9 @@ public class ScoreActionTest {
 
     @Test(expected = DependencyTrackException.class)
     public void thatWhenNoProjectsAreFoundThenAnExceptionIsThrown() throws DependencyTrackException {
-        doReturn(new Response(404, "Not Found", false)).when(projectClient).getProject(anyString(), anyString(), anyString());
+        doReturn(new Response(404, "Not Found", false))
+                .when(projectClient)
+                .getProject(anyString(), anyString(), anyString());
 
         scoreAction.determineScore(new ModuleConfig(), INHERITED_RISK_SCORE_THRESHOLD);
         fail("Exception expected");
@@ -60,8 +62,11 @@ public class ScoreActionTest {
 
     @Test
     public void thatWhenTheCurrentProjectHasMetricsInItThenTheScoreIsReturned() throws Exception {
-        Project project = aProject().withMetrics(aMetrics().withInheritedRiskScore(100)).build();
-        doReturn(aSuccessResponse().withBody(project).build()).when(projectClient).getProject(anyString(), anyString(), anyString());
+        Project project =
+                aProject().withMetrics(aMetrics().withInheritedRiskScore(100)).build();
+        doReturn(aSuccessResponse().withBody(project).build())
+                .when(projectClient)
+                .getProject(anyString(), anyString(), anyString());
 
         Integer score = scoreAction.determineScore(new ModuleConfig(), INHERITED_RISK_SCORE_THRESHOLD);
         assertThat(score, is(equalTo(100)));
@@ -72,9 +77,12 @@ public class ScoreActionTest {
     @Test
     public void thatWhenTheCurrentProjectHasNoMetricsInItTheyAreRequestedAndThenTheScoreIsReturned() throws Exception {
         Project project = aProject().build();
-        doReturn(aSuccessResponse().withBody(project).build()).when(projectClient).getProject(anyString(), anyString(), anyString());
-        doReturn(aMetrics().withInheritedRiskScore(100).build()).when(metricsAction).getMetrics(
-                any(Project.class));
+        doReturn(aSuccessResponse().withBody(project).build())
+                .when(projectClient)
+                .getProject(anyString(), anyString(), anyString());
+        doReturn(aMetrics().withInheritedRiskScore(100).build())
+                .when(metricsAction)
+                .getMetrics(any(Project.class));
 
         Integer score = scoreAction.determineScore(new ModuleConfig(), INHERITED_RISK_SCORE_THRESHOLD);
         assertThat(score, is(equalTo(100)));
@@ -85,14 +93,16 @@ public class ScoreActionTest {
     @Test
     public void thatWhenTheCurrentProjectScoreIsZeroThenTheScoreIsReturned() throws Exception {
         Project project = aProject().build();
-        doReturn(aSuccessResponse().withBody(project).build()).when(projectClient).getProject(anyString(), anyString(), anyString());
-        doReturn(aMetrics().withInheritedRiskScore(0).build()).when(metricsAction).getMetrics(
-                any(Project.class));
+        doReturn(aSuccessResponse().withBody(project).build())
+                .when(projectClient)
+                .getProject(anyString(), anyString(), anyString());
+        doReturn(aMetrics().withInheritedRiskScore(0).build())
+                .when(metricsAction)
+                .getMetrics(any(Project.class));
 
         Integer score = scoreAction.determineScore(new ModuleConfig(), INHERITED_RISK_SCORE_THRESHOLD);
         assertThat(score, is(equalTo(0)));
 
         verify(metricsAction, times(1)).getMetrics(any(Project.class));
     }
-
 }

--- a/src/test/java/io/github/pmckeown/dependencytrack/score/ScoreMojoIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/score/ScoreMojoIntegrationTest.java
@@ -1,11 +1,5 @@
 package io.github.pmckeown.dependencytrack.score;
 
-import io.github.pmckeown.dependencytrack.AbstractDependencyTrackMojoTest;
-import io.github.pmckeown.dependencytrack.PollingConfig;
-import org.apache.maven.plugin.MojoFailureException;
-import org.junit.Before;
-import org.junit.Test;
-
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static io.github.pmckeown.TestMojoLoader.loadScoreMojo;
 import static io.github.pmckeown.dependencytrack.ResourceConstants.V1_PROJECT_LOOKUP;
@@ -14,6 +8,12 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
+
+import io.github.pmckeown.dependencytrack.AbstractDependencyTrackMojoTest;
+import io.github.pmckeown.dependencytrack.PollingConfig;
+import org.apache.maven.plugin.MojoFailureException;
+import org.junit.Before;
+import org.junit.Test;
 
 public class ScoreMojoIntegrationTest extends AbstractDependencyTrackMojoTest {
 
@@ -29,8 +29,8 @@ public class ScoreMojoIntegrationTest extends AbstractDependencyTrackMojoTest {
 
     @Test
     public void thatAllProjectsCanBeRetrieved() throws Exception {
-        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP)).willReturn(
-            aResponse().withBodyFile("api/v1/project/dependency-track-3.6.json")));
+        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP))
+                .willReturn(aResponse().withBodyFile("api/v1/project/dependency-track-3.6.json")));
 
         scoreMojo.execute();
 
@@ -40,8 +40,8 @@ public class ScoreMojoIntegrationTest extends AbstractDependencyTrackMojoTest {
     @Test
     public void thatARiskScoreHigherThanTheThresholdCausesBuildToFailEvenWithFailOnErrorFalse() throws Exception {
         // The current project score in the JSON file is 3
-        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP)).willReturn(
-            aResponse().withBodyFile("api/v1/project/dependency-track-3.6.json")));
+        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP))
+                .willReturn(aResponse().withBodyFile("api/v1/project/dependency-track-3.6.json")));
 
         scoreMojo.setInheritedRiskScoreThreshold(1);
         scoreMojo.setFailOnError(false);
@@ -57,8 +57,8 @@ public class ScoreMojoIntegrationTest extends AbstractDependencyTrackMojoTest {
     @Test
     public void thatARiskScoreEqualToTheThresholdDoesNothing() throws Exception {
         // The current project score in the JSON file is 3
-        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP)).willReturn(
-            aResponse().withBodyFile("api/v1/project/dependency-track-3.6.json")));
+        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP))
+                .willReturn(aResponse().withBodyFile("api/v1/project/dependency-track-3.6.json")));
 
         scoreMojo.setInheritedRiskScoreThreshold(3);
 
@@ -72,8 +72,8 @@ public class ScoreMojoIntegrationTest extends AbstractDependencyTrackMojoTest {
     @Test
     public void thatFailureToGetARiskScoreEqualThrowsAnException() throws Exception {
         // The current project score in the JSON file is 3
-        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP)).willReturn(
-            aResponse().withBodyFile("api/v1/project/dependency-track-3.6.json")));
+        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP))
+                .willReturn(aResponse().withBodyFile("api/v1/project/dependency-track-3.6.json")));
 
         scoreMojo.setInheritedRiskScoreThreshold(3);
 
@@ -87,8 +87,8 @@ public class ScoreMojoIntegrationTest extends AbstractDependencyTrackMojoTest {
     @Test
     public void thatARiskScoreLowerThanTheThresholdDoesNothing() throws Exception {
         // The current project score in the JSON file is 3
-        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP)).willReturn(
-            aResponse().withBodyFile("api/v1/project/dependency-track-3.6.json")));
+        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP))
+                .willReturn(aResponse().withBodyFile("api/v1/project/dependency-track-3.6.json")));
 
         scoreMojo.setInheritedRiskScoreThreshold(999);
 
@@ -102,10 +102,10 @@ public class ScoreMojoIntegrationTest extends AbstractDependencyTrackMojoTest {
     @Test
     public void thatWhenNoMetricsHaveBeenCalculatedThenTheMetricsAreRetrieved() throws Exception {
         // The current project score in the JSON file is 3
-        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP)).willReturn(
-            aResponse().withBodyFile("api/v1/project/noMetrics.json")));
-        stubFor(get(urlPathMatching(V1_METRICS_PROJECT_CURRENT)).willReturn(
-                aResponse().withBodyFile("api/v1/metrics/project/project-metrics.json")));
+        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP))
+                .willReturn(aResponse().withBodyFile("api/v1/project/noMetrics.json")));
+        stubFor(get(urlPathMatching(V1_METRICS_PROJECT_CURRENT))
+                .willReturn(aResponse().withBodyFile("api/v1/metrics/project/project-metrics.json")));
 
         scoreMojo.setProjectName("noMetrics");
         scoreMojo.setProjectVersion("1.0.0");
@@ -117,10 +117,10 @@ public class ScoreMojoIntegrationTest extends AbstractDependencyTrackMojoTest {
     @Test
     public void thatWhenNoMetricsHaveBeenTheTheCallIsRetriedTheCorrectNumberOfTimes() throws Exception {
         // The current project score in the JSON file is 3
-        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP)).willReturn(
-            aResponse().withBodyFile("api/v1/project/noMetrics.json")));
-        stubFor(get(urlPathMatching(V1_METRICS_PROJECT_CURRENT)).willReturn(
-                aResponse().withStatus(404).withBody("The project could not be found.")));
+        stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP))
+                .willReturn(aResponse().withBodyFile("api/v1/project/noMetrics.json")));
+        stubFor(get(urlPathMatching(V1_METRICS_PROJECT_CURRENT))
+                .willReturn(aResponse().withStatus(404).withBody("The project could not be found.")));
 
         scoreMojo.setProjectName("noMetrics");
         scoreMojo.setProjectVersion("1.0.0");

--- a/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomActionTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomActionTest.java
@@ -1,17 +1,5 @@
 package io.github.pmckeown.dependencytrack.upload;
 
-import io.github.pmckeown.dependencytrack.*;
-import io.github.pmckeown.util.BomEncoder;
-import io.github.pmckeown.util.Logger;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
-
-import java.util.Optional;
-
 import static io.github.pmckeown.dependencytrack.PollingConfig.TimeUnit.MILLIS;
 import static io.github.pmckeown.dependencytrack.upload.UploadBomResponseBuilder.anUploadBomResponse;
 import static org.hamcrest.CoreMatchers.*;
@@ -20,6 +8,17 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
+
+import io.github.pmckeown.dependencytrack.*;
+import io.github.pmckeown.util.BomEncoder;
+import io.github.pmckeown.util.Logger;
+import java.util.Optional;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class UploadBomActionTest {
@@ -102,13 +101,14 @@ public class UploadBomActionTest {
         doReturn(new PollingConfig(true, 1, 3, MILLIS)).when(commonConfig).getPollingConfig();
 
         // Create a new candidate as the polling behaviour needs to change for this test
-        UploadBomAction uploadBomAction = new UploadBomAction(bomClient, bomEncoder, new Poller<Boolean>(),
-                commonConfig, logger);
+        UploadBomAction uploadBomAction =
+                new UploadBomAction(bomClient, bomEncoder, new Poller<Boolean>(), commonConfig, logger);
 
         doReturn(aBomProcessingResponse(true))
                 .doReturn(aBomProcessingResponse(true))
                 .doReturn(aBomProcessingResponse(false))
-                .when(bomClient).isBomBeingProcessed(anyString());
+                .when(bomClient)
+                .isBomBeingProcessed(anyString());
 
         uploadBomAction.upload(moduleConfig);
 
@@ -120,17 +120,20 @@ public class UploadBomActionTest {
      */
 
     private Response<BomProcessingResponse> aBomProcessingResponse(boolean processing) {
-        return new Response<>(200, "OK", true,
-                Optional.of(BomProcessingResponseBuilder.aBomProcessingResponse().withProcessing(processing).build()));
+        return new Response<>(
+                200,
+                "OK",
+                true,
+                Optional.of(BomProcessingResponseBuilder.aBomProcessingResponse()
+                        .withProcessing(processing)
+                        .build()));
     }
 
     private Response<UploadBomResponse> anUploadBomSuccessResponse() {
-        return new Response<>(200, "OK", true,
-                Optional.of(anUploadBomResponse().build()));
+        return new Response<>(200, "OK", true, Optional.of(anUploadBomResponse().build()));
     }
 
     private Response aNotFoundResponse() {
         return new Response(404, "Not Found", false, Optional.of("The parent component could not be found."));
     }
-
 }

--- a/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoIntegrationTest.java
@@ -1,23 +1,5 @@
 package io.github.pmckeown.dependencytrack.upload;
 
-import io.github.pmckeown.dependencytrack.AbstractDependencyTrackMojoTest;
-import io.github.pmckeown.dependencytrack.PollingConfig;
-import io.github.pmckeown.dependencytrack.ResourceConstants;
-import io.github.pmckeown.dependencytrack.TestResourceConstants;
-import io.github.pmckeown.util.BomEncoder;
-import io.github.pmckeown.util.Logger;
-import kong.unirest.Unirest;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-
-import java.util.HashSet;
-import java.util.Optional;
-import java.util.Set;
-
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static io.github.pmckeown.TestMojoLoader.loadUploadBomMojo;
 import static io.github.pmckeown.dependencytrack.ResourceConstants.V1_BOM;
@@ -29,6 +11,23 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
+
+import io.github.pmckeown.dependencytrack.AbstractDependencyTrackMojoTest;
+import io.github.pmckeown.dependencytrack.PollingConfig;
+import io.github.pmckeown.dependencytrack.ResourceConstants;
+import io.github.pmckeown.dependencytrack.TestResourceConstants;
+import io.github.pmckeown.util.BomEncoder;
+import io.github.pmckeown.util.Logger;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import kong.unirest.Unirest;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 public class UploadBomMojoIntegrationTest extends AbstractDependencyTrackMojoTest {
 
@@ -137,9 +136,10 @@ public class UploadBomMojoIntegrationTest extends AbstractDependencyTrackMojoTes
         uploadBomMojo.setProjectName("test-project");
         uploadBomMojo.execute();
 
-        verify(exactly(1), putRequestedFor(urlEqualTo(V1_BOM))
-                .withRequestBody(
-                        matchingJsonPath("$.projectName", equalTo("test-project"))));
+        verify(
+                exactly(1),
+                putRequestedFor(urlEqualTo(V1_BOM))
+                        .withRequestBody(matchingJsonPath("$.projectName", equalTo("test-project"))));
     }
 
     @Test
@@ -149,37 +149,39 @@ public class UploadBomMojoIntegrationTest extends AbstractDependencyTrackMojoTes
         UploadBomMojo uploadBomMojo = uploadBomMojo(BOM_LOCATION);
         uploadBomMojo.execute();
 
-        verify(exactly(1), putRequestedFor(urlEqualTo(V1_BOM))
-                .withRequestBody(
-                        matchingJsonPath("$.projectName", equalTo("dependency-track-maven-plugin-test-project"))));
+        verify(
+                exactly(1),
+                putRequestedFor(urlEqualTo(V1_BOM))
+                        .withRequestBody(matchingJsonPath(
+                                "$.projectName", equalTo("dependency-track-maven-plugin-test-project"))));
     }
 
     @Test
     public void thatProjectVersionCanBeProvided() throws Exception {
         stubFor(put(urlEqualTo(V1_BOM)).willReturn(ok()));
 
-
         UploadBomMojo uploadBomMojo = uploadBomMojo(BOM_LOCATION);
         uploadBomMojo.setProjectVersion("99.99.99-RELEASE");
         uploadBomMojo.execute();
 
-        verify(exactly(1), putRequestedFor(urlEqualTo(V1_BOM))
-                .withRequestBody(
-                        matchingJsonPath("$.projectVersion", equalTo("99.99.99-RELEASE"))));
+        verify(
+                exactly(1),
+                putRequestedFor(urlEqualTo(V1_BOM))
+                        .withRequestBody(matchingJsonPath("$.projectVersion", equalTo("99.99.99-RELEASE"))));
     }
 
     @Test
     public void thatProjectIsLatestCanBeProvided() throws Exception {
         stubFor(put(urlEqualTo(V1_BOM)).willReturn(ok()));
 
-
         UploadBomMojo uploadBomMojo = uploadBomMojo(BOM_LOCATION);
         uploadBomMojo.setLatest(true);
         uploadBomMojo.execute();
 
-        verify(exactly(1), putRequestedFor(urlEqualTo(V1_BOM))
-                .withRequestBody(
-                        matchingJsonPath("$.isLatestProjectVersion", equalTo("true"))));
+        verify(
+                exactly(1),
+                putRequestedFor(urlEqualTo(V1_BOM))
+                        .withRequestBody(matchingJsonPath("$.isLatestProjectVersion", equalTo("true"))));
     }
 
     @Test
@@ -194,9 +196,11 @@ public class UploadBomMojoIntegrationTest extends AbstractDependencyTrackMojoTes
         uploadBomMojo.setProjectTags(tags);
         uploadBomMojo.execute();
 
-        verify(exactly(1), putRequestedFor(urlEqualTo(V1_BOM))
-            .withRequestBody(
-                matchingJsonPath("$.projectTags", equalToJson("[{\"name\":\"Backend\"},{\"name\":\"Team-1\"}]"))));
+        verify(
+                exactly(1),
+                putRequestedFor(urlEqualTo(V1_BOM))
+                        .withRequestBody(matchingJsonPath(
+                                "$.projectTags", equalToJson("[{\"name\":\"Backend\"},{\"name\":\"Team-1\"}]"))));
     }
 
     @Test
@@ -206,9 +210,10 @@ public class UploadBomMojoIntegrationTest extends AbstractDependencyTrackMojoTes
         UploadBomMojo uploadBomMojo = uploadBomMojo(BOM_LOCATION);
         uploadBomMojo.execute();
 
-        verify(exactly(1), putRequestedFor(urlEqualTo(V1_BOM))
-                .withRequestBody(
-                        matchingJsonPath("$.projectVersion", equalTo("0.0.1-SNAPSHOT"))));
+        verify(
+                exactly(1),
+                putRequestedFor(urlEqualTo(V1_BOM))
+                        .withRequestBody(matchingJsonPath("$.projectVersion", equalTo("0.0.1-SNAPSHOT"))));
     }
 
     @Test
@@ -234,13 +239,14 @@ public class UploadBomMojoIntegrationTest extends AbstractDependencyTrackMojoTes
     @Test
     public void thatProjectParentNameAndVersionCanBeIgnored() throws Exception {
         stubFor(get(urlPathEqualTo(V1_PROJECT_LOOKUP))
-            .willReturn(aResponse().withBodyFile("api/v1/project/test-project.json")));
+                .willReturn(aResponse().withBodyFile("api/v1/project/test-project.json")));
         stubFor(get(urlPathMatching(TestResourceConstants.V1_PROJECT_UUID)).willReturn(ok()));
         stubFor(patch(urlPathMatching(TestResourceConstants.V1_PROJECT_UUID)).willReturn(ok()));
         stubFor(get(urlPathMatching(TestResourceConstants.V1_BOM_TOKEN_UUID)).willReturn(ok()));
-        stubFor(put(urlEqualTo(V1_BOM)).willReturn(
-                aResponse().withBodyFile("api/v1/project/upload-bom-response.json")));
-        stubFor(get(urlPathMatching(TestResourceConstants.V1_METRICS_PROJECT_REFRESH)).willReturn(ok()));
+        stubFor(put(urlEqualTo(V1_BOM))
+                .willReturn(aResponse().withBodyFile("api/v1/project/upload-bom-response.json")));
+        stubFor(get(urlPathMatching(TestResourceConstants.V1_METRICS_PROJECT_REFRESH))
+                .willReturn(ok()));
 
         UploadBomMojo uploadBomMojo = uploadBomMojo(BOM_LOCATION);
         uploadBomMojo.setProjectName("test-project");

--- a/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoTest.java
@@ -1,10 +1,15 @@
 package io.github.pmckeown.dependencytrack.upload;
 
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.*;
+
 import io.github.pmckeown.dependencytrack.CommonConfig;
 import io.github.pmckeown.dependencytrack.ModuleConfig;
 import io.github.pmckeown.dependencytrack.metrics.MetricsAction;
 import io.github.pmckeown.dependencytrack.project.ProjectAction;
 import io.github.pmckeown.util.Logger;
+import java.util.Collections;
 import kong.unirest.Unirest;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
@@ -15,12 +20,6 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import java.util.Collections;
-
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class UploadBomMojoTest {
@@ -167,7 +166,8 @@ public class UploadBomMojoTest {
             assertThat(ex, instanceOf(MojoExecutionException.class));
         }
 
-        verify(logger).error("Parent update requested but no parent found in parent maven project or provided in " +
-                "config");
+        verify(logger)
+                .error("Parent update requested but no parent found in parent maven project or provided in "
+                        + "config");
     }
 }

--- a/src/test/java/io/github/pmckeown/util/BomEncoderTest.java
+++ b/src/test/java/io/github/pmckeown/util/BomEncoderTest.java
@@ -1,14 +1,13 @@
 package io.github.pmckeown.util;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.Optional;
 import org.apache.maven.plugin.testing.SilentLog;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import java.util.Optional;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 @RunWith(MockitoJUnitRunner.class)
 public class BomEncoderTest {

--- a/src/test/java/io/github/pmckeown/util/LoggerTest.java
+++ b/src/test/java/io/github/pmckeown/util/LoggerTest.java
@@ -1,5 +1,11 @@
 package io.github.pmckeown.util;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
 import org.apache.maven.plugin.logging.Log;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -7,12 +13,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class LoggerTest {
@@ -105,5 +105,4 @@ public class LoggerTest {
             assertThat(ex, is(instanceOf(IllegalStateException.class)));
         }
     }
-
 }


### PR DESCRIPTION
resolves #447 

Add the maven spotless plugin to enforce the coding style during the verify phase.

The following spotless formatters are used:
- [Palantir java format](https://github.com/palantir/palantir-java-format) -- based on Google's, but better fits the current code style. Also has tooling support for various IDEs
- removes unused imports
- sort pom to make the Maven pom files nicer

In the end it really does not matter if people follow the code style during development, as long as they execute `mvn spotless:apply` before committing to reformat.