### PR TITLE
Always log to error when handling failures

### DIFF
--- a/src/main/java/io/github/pmckeown/dependencytrack/AbstractDependencyTrackMojo.java
+++ b/src/main/java/io/github/pmckeown/dependencytrack/AbstractDependencyTrackMojo.java
@@ -159,9 +159,9 @@ public abstract class AbstractDependencyTrackMojo extends AbstractMojo {
     }
 
     protected void handleFailure(String message, Throwable ex) throws MojoExecutionException {
-        getLog().debug(message, ex);
+        getLog().error(message, ex);
         if (failOnError) {
-            throw new MojoExecutionException(message);
+            throw new MojoExecutionException(message, ex);
         }
     }
 

--- a/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsActionTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/policyviolation/PolicyViolationsActionTest.java
@@ -76,7 +76,6 @@ public class PolicyViolationsActionTest {
             policyAction.getPolicyViolations(project);
             fail("Exception expected");
         } catch (Exception ex) {
-            logger.debug("DependencyTrackException ", ex.getMessage());
             assertThat(ex, is(instanceOf(DependencyTrackException.class)));
         }
     }
@@ -90,7 +89,6 @@ public class PolicyViolationsActionTest {
             policyAction.getPolicyViolations(project);
             fail("Exception expected");
         } catch (Exception ex) {
-            logger.debug("DependencyTrackException ", ex.getMessage());
             assertThat(ex, is(instanceOf(DependencyTrackException.class)));
         }
     }

--- a/src/test/java/io/github/pmckeown/dependencytrack/project/DeleteProjectActionTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/project/DeleteProjectActionTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
@@ -59,6 +60,7 @@ public class DeleteProjectActionTest {
 
         try {
             projectAction.deleteProject(aProject().build());
+            fail("Exception expected");
         } catch (Exception ex) {
             assertThat(ex, is(instanceOf(DependencyTrackException.class)));
         }

--- a/src/test/java/io/github/pmckeown/dependencytrack/project/DeleteProjectMojoIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/project/DeleteProjectMojoIntegrationTest.java
@@ -81,11 +81,7 @@ public class DeleteProjectMojoIntegrationTest extends AbstractDependencyTrackMoj
         deleteProjectMojo.setProjectName("unknown");
         deleteProjectMojo.setProjectVersion("1.2.3-SNAPSHOT");
 
-        try {
-            deleteProjectMojo.execute();
-        } catch (MojoExecutionException ex) {
-            assertThat(ex, is(instanceOf(MojoExecutionException.class)));
-        }
+        deleteProjectMojo.execute();
 
         verify(exactly(0), deleteRequestedFor(urlPathMatching(V1_PROJECT_UUID)));
     }
@@ -101,6 +97,7 @@ public class DeleteProjectMojoIntegrationTest extends AbstractDependencyTrackMoj
 
         try {
             deleteProjectMojo.execute();
+            fail("Exception expected");
         } catch (Exception ex) {
             assertThat(ex, is(instanceOf(MojoExecutionException.class)));
         }

--- a/src/test/java/io/github/pmckeown/dependencytrack/project/ProjectActionTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/project/ProjectActionTest.java
@@ -88,6 +88,7 @@ public class ProjectActionTest {
 
         try {
             projectAction.getProject(getModuleConfig());
+            fail("Exception expected");
         } catch (Exception ex) {
             assertThat(ex, is(instanceOf(DependencyTrackException.class)));
         }
@@ -106,6 +107,7 @@ public class ProjectActionTest {
 
         try {
             projectAction.getProject(getModuleConfig());
+            fail("Exception expected");
         } catch (Exception ex) {
             assertThat(ex, is(instanceOf(DependencyTrackException.class)));
         }

--- a/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomActionTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomActionTest.java
@@ -84,10 +84,14 @@ public class UploadBomActionTest {
 
     @Test
     public void thatBomUploadExceptionResultsInException() {
+        doReturn(BOM_LOCATION).when(moduleConfig).getBomLocation();
+        doReturn(Optional.of("encoded-bom")).when(bomEncoder).encodeBom(BOM_LOCATION, logger);
+        doThrow(RuntimeException.class).when(bomClient).uploadBom(any());
         doReturn(PollingConfig.disabled()).when(commonConfig).getPollingConfig();
 
         try {
             uploadBomAction.upload(moduleConfig);
+            fail("Exception expected");
         } catch (Exception ex) {
             assertThat(ex, is(instanceOf(DependencyTrackException.class)));
         }

--- a/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoIntegrationTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoIntegrationTest.java
@@ -10,7 +10,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
 
 import io.github.pmckeown.dependencytrack.AbstractDependencyTrackMojoTest;
 import io.github.pmckeown.dependencytrack.PollingConfig;
@@ -26,9 +26,11 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
 
+@RunWith(MockitoJUnitRunner.class)
 public class UploadBomMojoIntegrationTest extends AbstractDependencyTrackMojoTest {
 
     private static final String BOM_LOCATION = "target/test-classes/projects/run/bom.xml";
@@ -38,8 +40,7 @@ public class UploadBomMojoIntegrationTest extends AbstractDependencyTrackMojoTes
 
     @Before
     public void setup() {
-        MockitoAnnotations.initMocks(this);
-        doReturn(Optional.of("encoded-bom")).when(bomEncoder).encodeBom(anyString(), any(Logger.class));
+        lenient().doReturn(Optional.of("encoded-bom")).when(bomEncoder).encodeBom(anyString(), any(Logger.class));
     }
 
     @After

--- a/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoTest.java
+++ b/src/test/java/io/github/pmckeown/dependencytrack/upload/UploadBomMojoTest.java
@@ -190,7 +190,7 @@ public class UploadBomMojoTest {
         uploadBomMojo.setFailOnError(true);
 
         MojoExecutionException exception = assertThrows(MojoExecutionException.class, () -> uploadBomMojo.execute());
-            assertThat(exception.getCause(), is(cause));
+        assertThat(exception.getCause(), is(cause));
 
         verify(mavenLogger).error("Error occurred during upload", cause);
     }


### PR DESCRIPTION
This resolves #450. When throwing a Maven exception, also include the cause.

I also went through all the test cases to ensure that when exceptions were expected the test would also fail if the exception was not thrown. This uncovered that the `thatBomUploadExceptionResultsInException` was broken a while ago.

